### PR TITLE
Use Temp Path

### DIFF
--- a/swxsoc_reach/calibration/calibration.py
+++ b/swxsoc_reach/calibration/calibration.py
@@ -2,7 +2,9 @@
 Pipeline entry point for processing REACH UDL files into CDF.
 """
 
+import os
 from pathlib import Path
+import tempfile
 
 from swxsoc.util.validation import validate
 
@@ -42,13 +44,16 @@ def process_file(
     # Stub Output Files
     output_files = []
 
-    # Save to the working directory
-    output_path = Path.cwd()
-
     # Read and transform
     data = read_file(file_path)
     reach_data = build_swxdata(data)
 
+    # Check if the LAMBDA_ENVIRONMENT environment variable is set
+    lambda_environment = os.getenv("LAMBDA_ENVIRONMENT")
+    if lambda_environment:
+        output_path = Path(tempfile.gettempdir())
+    else:
+        output_path = Path.cwd()  # Default to current working directory
     # Write CDF
     cdf_path = reach_data.save(output_path=output_path, overwrite=True)
     log.info(f"Saved CDF to {cdf_path}")

--- a/swxsoc_reach/util/util.py
+++ b/swxsoc_reach/util/util.py
@@ -1,6 +1,3 @@
-import os
-from pathlib import Path
-import tempfile
 from swxsoc.util import create_science_filename, parse_science_filename
 
 __all__ = [
@@ -56,13 +53,4 @@ def create_reach_filename(
         descriptor=descriptor,
         test=test,
     )
-
-    # Check if the LAMBDA_ENVIRONMENT environment variable is set
-    lambda_environment = os.getenv("LAMBDA_ENVIRONMENT")
-    if lambda_environment:
-        temp_dir = Path(tempfile.gettempdir())  # Set to temp directory
-        output_path = temp_dir / base_filename
-    else:
-        output_path = Path(base_filename)
-
-    return output_path
+    return base_filename

--- a/swxsoc_reach/util/util.py
+++ b/swxsoc_reach/util/util.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+import tempfile
 from swxsoc.util import create_science_filename, parse_science_filename
 
 __all__ = [
@@ -53,4 +56,13 @@ def create_reach_filename(
         descriptor=descriptor,
         test=test,
     )
-    return base_filename
+
+    # Check if the LAMBDA_ENVIRONMENT environment variable is set
+    lambda_environment = os.getenv("LAMBDA_ENVIRONMENT")
+    if lambda_environment:
+        temp_dir = Path(tempfile.gettempdir())  # Set to temp directory
+        output_path = temp_dir / base_filename
+    else:
+        output_path = Path(base_filename)
+
+    return output_path


### PR DESCRIPTION
File System permissions errors in the lambda environment require us to write to a `/tmp` directory when running in AWS. 