### PR TITLE
Initial Formatting Changes

### DIFF
--- a/swxsoc_reach/calibration/transform.py
+++ b/swxsoc_reach/calibration/transform.py
@@ -289,7 +289,11 @@ def build_swxdata(
     sensor_ids, _obs_names, observation_flavors = extract_sensor_metadata(data)
 
     # --- 3. Build common time axis -------------------------------------
-    times = Time(sorted(data["obTime"].unique())).sort()
+    # Strip trailing 'Z' and pass explicit scale/format to avoid a stack
+    # overflow in astropy's recursive ISO-8601 parser for large arrays.
+    unique_times_raw = sorted(data["obTime"].unique())
+    unique_times = [t[:-1] if t.endswith("Z") else t for t in unique_times_raw]
+    times = Time(unique_times, scale="utc", format="isot").sort()
     times_pd = pd.DatetimeIndex([t.datetime for t in times]).tz_localize("UTC")
 
     ts = TimeSeries(time=times)
@@ -338,7 +342,7 @@ def build_swxdata(
                 "VAR_TYPE": "data",
                 "UNITS": (u.J / u.kg * 0.01).to_string(),
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
                 "LABL_PTR_3": "Flavor_label",
@@ -353,7 +357,7 @@ def build_swxdata(
                 "VAR_TYPE": "data",
                 "UNITS": u.degree.to_string(),
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -367,7 +371,7 @@ def build_swxdata(
                 "VAR_TYPE": "data",
                 "UNITS": u.degree.to_string(),
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -381,7 +385,7 @@ def build_swxdata(
                 "VAR_TYPE": "data",
                 "UNITS": u.km.to_string(),
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -392,10 +396,10 @@ def build_swxdata(
             ),
             meta={
                 "CATDESC": "Observation Quality",
-                "VAR_TYPE": "data",
-                "UNITS": u.dimensionless_unscaled.to_string(),
+                "VAR_TYPE": "support_data",
+                "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -406,10 +410,10 @@ def build_swxdata(
             ),
             meta={
                 "CATDESC": "Sensor Position 0",
-                "VAR_TYPE": "data",
-                "UNITS": u.dimensionless_unscaled.to_string(),
+                "VAR_TYPE": "support_data",
+                "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -420,10 +424,10 @@ def build_swxdata(
             ),
             meta={
                 "CATDESC": "Sensor Position 1",
-                "VAR_TYPE": "data",
-                "UNITS": u.dimensionless_unscaled.to_string(),
+                "VAR_TYPE": "support_data",
+                "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },
@@ -434,10 +438,10 @@ def build_swxdata(
             ),
             meta={
                 "CATDESC": "Sensor Position 2",
-                "VAR_TYPE": "data",
-                "UNITS": u.dimensionless_unscaled.to_string(),
+                "VAR_TYPE": "support_data",
+                "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
-                "DEPEND_2": "sensor_ids",
+                "DEPEND_1": "sensor_ids",
                 "LABL_PTR_1": "Epoch_label",
                 "LABL_PTR_2": "sensor_ids",
             },

--- a/swxsoc_reach/calibration/transform.py
+++ b/swxsoc_reach/calibration/transform.py
@@ -239,12 +239,25 @@ def build_swxdata(
     global_attrs: dict | None = None,
 ) -> SWXData:
     """
-    Assemble an :class:`~swxsoc.swxdata.SWXData` object from a deduplicated
-    REACH DataFrame.
+    Assemble an :class:`~swxsoc.swxdata.SWXData` object from a raw REACH DataFrame.
 
-    This is the main entry point for the transformation layer.  It
-    orchestrates deduplication, metadata extraction, sparse-array
-    construction, and SWXData packaging in a single call.
+    This is the main entry point for the transformation layer.  It runs
+    the following pipeline in order:
+
+    1. **Deduplicate** records via :func:`deduplicate_records`.
+    2. **Extract sensor metadata** (sensor IDs, observatory names, flavors)
+       via :func:`extract_sensor_metadata`.
+    3. **Build common time axis** from the unique UTC observation timestamps,
+       stripping any trailing ``Z`` before parsing to avoid a stack overflow
+       in astropy's recursive ISO-8601 parser for large arrays.
+    4. **Pre-compute per-sensor groupby** on a sensor-deduplicated view of
+       the data for efficient scalar-column extraction.
+    5. **Build variable dict** of :class:`~astropy.nddata.NDData` arrays
+       (observations, attitude, quality, sensor-position, and label variables).
+    6. **Seed global attributes** from :class:`~swxsoc_reach.util.schema.REACHDataSchema`
+       defaults, then overlay *version* and any caller-supplied *global_attrs*.
+    7. **Assemble and return** a :class:`~swxsoc.swxdata.SWXData` instance
+       ready to be written to CDF.
 
     The returned :class:`~swxsoc.swxdata.SWXData` contains:
 
@@ -252,8 +265,10 @@ def build_swxdata(
     Variable                  Shape
     ========================  ==========================================
     ``Epoch``                 ``(n_times,)``
+    ``Epoch_label``           ``(n_times,)``
     ``sensor_ids``            ``(n_sensors,)``
     ``observation_flavors``   ``(n_sensors, n_flavors_max)``
+    ``Flavor_label``          ``(n_flavors_max,)``
     ``observations``          ``(n_times, n_sensors, n_flavors_max)``
     ``lat``                   ``(n_times, n_sensors)``
     ``lon``                   ``(n_times, n_sensors)``
@@ -268,7 +283,8 @@ def build_swxdata(
     ----------
     data : pd.DataFrame
         Raw (flat) DataFrame as returned by
-        :func:`~swxsoc_reach.io.file_tools.read_udl_json` or :func:`~swxsoc_reach.io.file_tools.read_udl_csv`.
+        :func:`~swxsoc_reach.io.file_tools.read_udl_json` or
+        :func:`~swxsoc_reach.io.file_tools.read_udl_csv`.
     version : str, optional
         Data version string written into the global attributes
         (default ``"1.0.0"``).
@@ -320,10 +336,10 @@ def build_swxdata(
                 "VAR_TYPE": "metadata",
             },
         ),
-        "Epoch_label": NDData(
-            data=np.array([t.isot for t in times]),
-            meta={"CATDESC": "Label for Epoch dimension", "VAR_TYPE": "metadata"},
-        ),
+        # "Epoch_label": NDData(
+        #     data=np.array([t.isot for t in times]),
+        #     meta={"CATDESC": "Label for Epoch dimension", "VAR_TYPE": "metadata"},
+        # ),
         "Flavor_label": NDData(
             data=np.array(
                 [f"flavor_{i}" for i in range(len(observation_flavors[0]))]
@@ -343,7 +359,7 @@ def build_swxdata(
                 "UNITS": (u.J / u.kg * 0.01).to_string(),
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
                 "LABL_PTR_3": "Flavor_label",
             },
@@ -358,7 +374,7 @@ def build_swxdata(
                 "UNITS": u.degree.to_string(),
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -372,7 +388,7 @@ def build_swxdata(
                 "UNITS": u.degree.to_string(),
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -386,7 +402,7 @@ def build_swxdata(
                 "UNITS": u.km.to_string(),
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -400,7 +416,7 @@ def build_swxdata(
                 "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -414,7 +430,7 @@ def build_swxdata(
                 "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -428,7 +444,7 @@ def build_swxdata(
                 "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),
@@ -442,7 +458,7 @@ def build_swxdata(
                 "UNITS": "unitless",
                 "DEPEND_0": "Epoch",
                 "DEPEND_1": "sensor_ids",
-                "LABL_PTR_1": "Epoch_label",
+                "LABL_PTR_1": "Epoch",
                 "LABL_PTR_2": "sensor_ids",
             },
         ),

--- a/swxsoc_reach/data/reach_default_global_cdf_attrs_schema.yaml
+++ b/swxsoc_reach/data/reach_default_global_cdf_attrs_schema.yaml
@@ -143,6 +143,15 @@ Discipline:
   required: true
   overwrite: false
 
+File_naming_convention:
+  description: >
+    If File_naming_convention was not set, it uses default setting:
+      instrument_instrument-mode_data-level_data-type_start-time_vX.Y.Z.ext
+  default: instrument_instrument-mode_data-level_data-type_start-time_vX.Y.Z.ext
+  derived: false
+  required: false
+  overwrite: false
+
 Generated_by:
   description: >
     Organisation(s) that generated the data file.

--- a/swxsoc_reach/tests/test_util.py
+++ b/swxsoc_reach/tests/test_util.py
@@ -2,16 +2,16 @@ import pytest
 
 import swxsoc_reach.util.util as util
 
-TIME = "2024-04-06T12:06:21"
-TIME_FORMATTED = "20240406T120621"
+TIME = "2024-04-06T00:00:00"
+TIME_FORMATTED = "20240406"
 
 
 # fmt: off
 @pytest.mark.parametrize("time,level,version,descriptor,result", [
-    (TIME, "l1", "1.2.3", "all", f"swxsoc_pipeline_reach_l1_all_{TIME_FORMATTED}_v1.2.3.cdf"),
-    (TIME, "l2", "2.4.5", "all", f"swxsoc_pipeline_reach_l2_all_{TIME_FORMATTED}_v2.4.5.cdf"),
-    (TIME, "l2", "1.3.5", "sci", f"swxsoc_pipeline_reach_l2_sci_{TIME_FORMATTED}_v1.3.5.cdf"),
-    (TIME, "l3", "2.4.5", "cal", f"swxsoc_pipeline_reach_l3_cal_{TIME_FORMATTED}_v2.4.5.cdf"),
+    (TIME, "l1", "1.2.3", "all", f"reach_l1_all_{TIME_FORMATTED}_v1.2.3.cdf"),
+    (TIME, "l2", "2.4.5", "all", f"reach_l2_all_{TIME_FORMATTED}_v2.4.5.cdf"),
+    (TIME, "l2", "1.3.5", "sci", f"reach_l2_sci_{TIME_FORMATTED}_v1.3.5.cdf"),
+    (TIME, "l3", "2.4.5", "cal", f"reach_l3_cal_{TIME_FORMATTED}_v2.4.5.cdf"),
 ])
 def test_create_reach_filename(time, level, version, descriptor, result):
     """Test that create_reach_filename generates correct CDF filenames.
@@ -25,9 +25,9 @@ def test_create_reach_filename(time, level, version, descriptor, result):
 
 # fmt: off
 @pytest.mark.parametrize("time,level,version,descriptor,result", [
-    (TIME, "l1", "1.2.3", "all", f"swxsoc_pipeline_reach_l1_all_{TIME_FORMATTED}_v1.2.3.cdf"),
-    (TIME, "l2", "2.4.5", "hk",  f"swxsoc_pipeline_reach_l2_hk_{TIME_FORMATTED}_v2.4.5.cdf"),
-    (TIME, "l1", "1.0.0", "sci", f"swxsoc_pipeline_reach_l1_sci_{TIME_FORMATTED}_v1.0.0.cdf"),
+    (TIME, "l1", "1.2.3", "all", f"reach_l1_all_{TIME_FORMATTED}_v1.2.3.cdf"),
+    (TIME, "l2", "2.4.5", "hk",  f"reach_l2_hk_{TIME_FORMATTED}_v2.4.5.cdf"),
+    (TIME, "l1", "1.0.0", "sci", f"reach_l1_sci_{TIME_FORMATTED}_v1.0.0.cdf"),
 ])
 def test_create_reach_filename_descriptors(time, level, version, descriptor, result):
     """Test that different descriptors are correctly included in the filename."""
@@ -36,13 +36,3 @@ def test_create_reach_filename_descriptors(time, level, version, descriptor, res
         == result
     )
 # fmt: on
-
-
-def test_create_reach_filename_test_flag():
-    """Test that the test flag is passed through to the underlying swxsoc function."""
-    filename = util.create_reach_filename(
-        TIME, level="l1", descriptor="all", version="1.0.0", test=True
-    )
-    # When test=True, the swxsoc framework prepends or marks the filename as a test file
-    assert "reach" in filename
-    assert "l1" in filename

--- a/swxsoc_reach/util/schema.py
+++ b/swxsoc_reach/util/schema.py
@@ -113,6 +113,7 @@ class REACHDataSchema(SWXSchema):
             instrument_mode = self._get_instrument_mode(data)
 
             # Build Derivation
+            # reach_all_prelim
             logical_source = f"{instrument_id}_{instrument_mode}_{data_type_short_name}"
         else:
             logical_source = data.meta[attr_name]
@@ -158,10 +159,6 @@ class REACHDataSchema(SWXSchema):
                 swxsoc_reach.config["mission"]["file_extension"]
             )
 
-            # Remove the `swxsoc_pipeline` prefix from the filename if it exists
-            # NOTE: Removing the `mission_name` currently breaks the filename parsing.
-            # We'll need to revisit this later once we have a better understanding of what we want our filenames to look like.
-            # science_filename = science_filename.replace("swxsoc_pipeline_", "")
         else:
             science_filename = data.meta[attr_name]
         return science_filename

--- a/swxsoc_reach/util/util.py
+++ b/swxsoc_reach/util/util.py
@@ -1,9 +1,12 @@
-from swxsoc.util import create_science_filename, parse_science_filename
+from astropy.time import Time
+from swxsoc.util import parse_science_filename
 
 __all__ = [
     "create_reach_filename",
     "parse_science_filename",
 ]
+
+TIME_FORMAT = "%Y%m%d"  # YYYYMMDD
 
 
 def create_reach_filename(
@@ -12,45 +15,40 @@ def create_reach_filename(
     version: str,
     mode: str = "",
     descriptor: str = "",
-    test: bool = False,
 ):
     """
     Generate the REACH filename based on the provided parameters.
 
     Parameters
     ----------
-    time : Time
+    time : str
         The time associated with the data.
     level : str
         The data level (e.g., "L1", "L2").
+    version : str
+        The version string (e.g., "0.0.1"). This should be in the format major.minor.patch.
+        This should come from the global attribute `Data_version`.
+    mode : str
+        The instrument mode (e.g., "all"). This should come from the global attribute `Instrument_mode`.
     descriptor : str
-        The data descriptor (e.g., "SCI", "CAL").
-    test : str
-        The test identifier (e.g., "TEST1", "TEST2").
-    overwrite : bool
-        Whether to overwrite existing files.
+        The dataset descriptor (e.g., "prelim"). This should come from the global attribute `Data_type`.
 
     Returns
     -------
     str
         The generated REACH filename.
     """
-    # Filename Version X.Y.Z comes from two parts:
-    #   1. Files Version Base: X.Y comes from the Software Version -> Data Version Mapping
-    #   2. File Version Incrementor: Z starts at 0 and iterates for each new version based on what already exists in the filesystem.
-    # version_base = "1.0"
-    # version_increment = 0
-    # version_str = f"{version_base}.{version_increment}"
-    version_str = version
+    # Define Static Parts
+    instrument_shortname = "reach"
 
-    # The Base Filename is used for searching to see if we need to increase our version increment.
-    base_filename = create_science_filename(
-        instrument="reach",
-        time=time,
-        level=level,
-        version=version_str,
-        mode=mode,
-        descriptor=descriptor,
-        test=test,
+    # Format Time String
+    start_time = Time(time, format="isot")
+    time_str = start_time.strftime("%Y%m%d")
+
+    # Combine Parts into Filename
+    filename = (
+        f"{instrument_shortname}_{mode}_{level}_{descriptor}_{time_str}_v{version}.cdf"
     )
-    return base_filename
+    filename = filename.replace("__", "_")  # reformat if mode or descriptor not given
+
+    return filename


### PR DESCRIPTION
Update CDF Format based on feedback from SPDF:

- **Changed** — `create_reach_filename` overhaul, no longer using `swxsoc.util.util.create_science_filename` (direct filename construction, no `swxsoc_pipeline_` prefix, date truncated to `YYYYMMDD`, `test` param removed).
- **Added** — `File_naming_convention` schema attribute to reflect new file naming conventions
- **Changed** — `DEPEND_2` → `DEPEND_1` for `sensor_ids` on several CDF variables.
- **Changed** — `VAR_TYPE`/`UNITS` corrections for `obs_quality` and `sensor_pos_*` variables.
- **Fixed** — astropy stack overflow from large UTC timestamp arrays (strip `Z`, pass explicit `scale`/`format`).

resolves #9 