### PR TITLE
Integrate Adaptive Rate Controller

### DIFF
--- a/swxsoc_reach/net/udl.py
+++ b/swxsoc_reach/net/udl.py
@@ -341,6 +341,11 @@ def download_UDL_reach_to_file(
     window_seconds: int,
     output_dir: Path | str,
     max_concurrent_requests: int = 4,
+    initial_rate: float = 5.0,
+    additive_increase: float = 1.0,
+    multiplicative_decrease: float = 0.5,
+    min_rate: float = 5.0,
+    max_rate: float = 25.0,
 ) -> Path:
     """Download REACH data from UDL and write one combined output file.
 
@@ -364,6 +369,17 @@ def download_UDL_reach_to_file(
     max_concurrent_requests : int, optional
         Maximum number of chunk requests to run concurrently. Lower values are
         safer for unknown API limits; higher values can improve throughput.
+    initial_rate : float, optional
+        Starting request rate in requests per second for the AIMD rate
+        controller. Default is 5.0.
+    additive_increase : float, optional
+        Amount added to the rate after each successful request. Default is 1.0.
+    multiplicative_decrease : float, optional
+        Factor to multiply the rate by after a 429 response. Default is 0.5.
+    min_rate : float, optional
+        Minimum permitted request rate. Default is 5.0.
+    max_rate : float, optional
+        Maximum permitted request rate. Default is 25.0.
 
     Returns
     -------
@@ -406,7 +422,13 @@ def download_UDL_reach_to_file(
     )
     urls = get_reach_urllist(dtlist, sensor_id, descriptor)
 
-    rate_controller = AdaptiveRateController()
+    rate_controller = AdaptiveRateController(
+        initial_rate=initial_rate,
+        additive_increase=additive_increase,
+        multiplicative_decrease=multiplicative_decrease,
+        min_rate=min_rate,
+        max_rate=max_rate,
+    )
 
     combined_obs: list[dict[str, Any]] = []
     chunk_results: dict[str, list[dict[str, Any]]] = {}

--- a/swxsoc_reach/net/udl.py
+++ b/swxsoc_reach/net/udl.py
@@ -461,6 +461,13 @@ def download_UDL_reach_to_file(
     for dt in dtlist:
         combined_obs.extend(chunk_results.get(dt, []))
 
+    if not combined_obs:
+        raise ValueError(
+            f"No records returned for sensor '{sensor_id}' between "
+            f"{format_udl_timestamp(start_time)} and "
+            f"{format_udl_timestamp(end_time)}."
+        )
+
     filename = build_reach_output_filename(
         sensor_id=sensor_id,
         start_time=start_time,

--- a/swxsoc_reach/net/udl.py
+++ b/swxsoc_reach/net/udl.py
@@ -1,5 +1,8 @@
 import json
 import csv
+import random
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Literal
 from pathlib import Path
@@ -8,6 +11,71 @@ from astropy.time import Time, TimeDelta
 
 from swxsoc_reach import log
 from swxsoc_reach.util.util import TIME_FORMAT
+
+
+class AdaptiveRateController:
+    """Thread-safe AIMD rate controller for throttling HTTP requests.
+
+    Uses Additive Increase / Multiplicative Decrease to dynamically
+    adjust the permitted request rate based on server feedback.
+
+    Parameters
+    ----------
+    initial_rate : float, optional
+        Starting request rate in requests per second.
+    additive_increase : float, optional
+        Amount to add to the rate after each successful request.
+    multiplicative_decrease : float, optional
+        Factor to multiply the rate by after a rate-limit response.
+    min_rate : float, optional
+        Minimum permitted request rate.
+    max_rate : float, optional
+        Maximum permitted request rate.
+    """
+
+    def __init__(
+        self,
+        initial_rate: float = 5.0,
+        additive_increase: float = 1.0,
+        multiplicative_decrease: float = 0.5,
+        min_rate: float = 5.0,
+        max_rate: float = 25.0,
+    ):
+        self.rate = initial_rate
+        self.additive_increase = additive_increase
+        self.multiplicative_decrease = multiplicative_decrease
+        self.min_rate = min_rate
+        self.max_rate = max_rate
+        self._lock = threading.Lock()
+        self._last_request_time = 0.0
+
+    def acquire(self) -> None:
+        """Block until the next request is permitted under the current rate."""
+        with self._lock:
+            now = time.monotonic()
+            delay = 1.0 / self.rate
+            wait = self._last_request_time + delay - now
+            if wait > 0:
+                self._last_request_time = self._last_request_time + delay
+            else:
+                self._last_request_time = now
+
+        if wait > 0:
+            time.sleep(wait)
+
+    def record_success(self) -> None:
+        """Record a successful request and increase the rate additively."""
+        with self._lock:
+            self.rate = min(self.rate + self.additive_increase, self.max_rate)
+
+    def record_rate_limit(self) -> None:
+        """Record a rate-limit (429) response and decrease the rate."""
+        with self._lock:
+            self.rate = max(self.rate * self.multiplicative_decrease, self.min_rate)
+            log.warning(
+                "Rate limit hit, reducing request rate",
+                extra={"new_rate": self.rate},
+            )
 
 
 def format_udl_timestamp(value: Time) -> str:
@@ -177,8 +245,14 @@ def fetch_reach_chunk(
     url: str,
     auth_token: str,
     timeout_seconds: int = 120,
+    rate_controller: AdaptiveRateController | None = None,
+    max_retries: int = 5,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Fetch one UDL chunk and normalize the payload into a list of records.
+
+    Includes retry logic with exponential back-off and jitter for HTTP 429
+    responses. When a ``rate_controller`` is provided, it is used to
+    throttle requests and receives success/failure feedback.
 
     Parameters
     ----------
@@ -191,6 +265,11 @@ def fetch_reach_chunk(
     timeout_seconds : int, optional
         Request timeout in seconds.
         Default is 120 seconds to allow for large chunks or slow responses.
+    rate_controller : AdaptiveRateController or None, optional
+        Shared rate controller for AIMD throttling. If ``None``, no
+        throttling or adaptive feedback is applied.
+    max_retries : int, optional
+        Maximum number of retry attempts after a 429 response.
 
     Returns
     -------
@@ -200,24 +279,57 @@ def fetch_reach_chunk(
     Raises
     ------
     requests.HTTPError
-        If UDL responds with an unsuccessful status code.
+        If UDL responds with an unsuccessful status code after all retries.
     """
-    response = requests.get(
-        url,
-        headers={"Authorization": auth_token},
-        timeout=timeout_seconds,
-    )
-    response.raise_for_status()
+    for attempt in range(max_retries + 1):
+        # Wait for the rate controller to permit the next request.
+        # This enforces a delay of 1/rate seconds between requests
+        # across all threads sharing this controller.
+        if rate_controller is not None:
+            rate_controller.acquire()
 
-    obs_chunk = response.json()
-    if isinstance(obs_chunk, list):
-        normalized = obs_chunk
-    elif obs_chunk:
-        normalized = [obs_chunk]
-    else:
-        normalized = []
+        response = requests.get(
+            url,
+            headers={"Authorization": auth_token},
+            timeout=timeout_seconds,
+        )
 
-    return dt, normalized
+        if response.status_code == 429:
+            # Signal the rate controller to halve the request rate
+            # (multiplicative decrease) so other threads also slow down.
+            if rate_controller is not None:
+                rate_controller.record_rate_limit()
+
+            if attempt < max_retries:
+                # Exponential back-off with random jitter to prevent
+                # multiple threads from retrying in lockstep.
+                backoff = (2**attempt) + random.uniform(0, 1)
+                log.warning(
+                    f"Chunk {dt} got 429, retrying in {backoff:.1f}s "
+                    f"(attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(backoff)
+                continue
+            else:
+                log.error(f"Chunk {dt} failed after {max_retries} retries with 429")
+                response.raise_for_status()
+
+        response.raise_for_status()
+
+        # Signal the rate controller to nudge the request rate upward
+        # (additive increase) so throughput gradually recovers.
+        if rate_controller is not None:
+            rate_controller.record_success()
+
+        obs_chunk = response.json()
+        if isinstance(obs_chunk, list):
+            normalized = obs_chunk
+        elif obs_chunk:
+            normalized = [obs_chunk]
+        else:
+            normalized = []
+
+        return dt, normalized
 
 
 def download_UDL_reach_to_file(
@@ -294,6 +406,8 @@ def download_UDL_reach_to_file(
     )
     urls = get_reach_urllist(dtlist, sensor_id, descriptor)
 
+    rate_controller = AdaptiveRateController()
+
     combined_obs: list[dict[str, Any]] = []
     chunk_results: dict[str, list[dict[str, Any]]] = {}
 
@@ -304,7 +418,13 @@ def download_UDL_reach_to_file(
             total_chunks = len(urls)
             for request_index, (dt, url) in enumerate(urls.items(), start=1):
                 log.info(f"Queueing Chunk {request_index} of {total_chunks}")
-                future = executor.submit(fetch_reach_chunk, dt, url, auth_token)
+                future = executor.submit(
+                    fetch_reach_chunk,
+                    dt,
+                    url,
+                    auth_token,
+                    rate_controller=rate_controller,
+                )
                 future_to_chunk[future] = (request_index, dt)
 
             for future in as_completed(future_to_chunk):

--- a/swxsoc_reach/tests/test_udl.py
+++ b/swxsoc_reach/tests/test_udl.py
@@ -1,12 +1,15 @@
 import csv
 import json
 import tempfile
+import threading
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from astropy.time import Time
 
 import swxsoc_reach.net.udl as udl
+from swxsoc_reach.net.udl import AdaptiveRateController
 
 
 @pytest.mark.parametrize(
@@ -193,6 +196,8 @@ def test_download_udl_reach_to_file_json_with_monkeypatched_udl(monkeypatch):
     calls = []
 
     class FakeResponse:
+        status_code = 200
+
         def __init__(self, payload):
             self._payload = payload
 
@@ -278,6 +283,8 @@ def test_download_udl_reach_to_file_csv_with_monkeypatched_udl(monkeypatch):
     )
 
     class FakeResponse:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -344,3 +351,235 @@ def test_download_udl_reach_to_file_rejects_invalid_output_format(monkeypatch):
                 window_seconds=600,
                 output_dir=tmpdir,
             )
+
+
+# --- AdaptiveRateController tests ---
+
+
+class TestAdaptiveRateController:
+    def test_initial_rate(self):
+        rc = AdaptiveRateController(initial_rate=10.0)
+        assert rc.rate == 10.0
+
+    def test_record_success_increases_rate(self):
+        rc = AdaptiveRateController(
+            initial_rate=5.0, additive_increase=1.0, max_rate=25.0
+        )
+        rc.record_success()
+        assert rc.rate == 6.0
+        rc.record_success()
+        assert rc.rate == 7.0
+
+    def test_record_rate_limit_decreases_rate(self):
+        rc = AdaptiveRateController(
+            initial_rate=10.0, multiplicative_decrease=0.5, min_rate=5.0
+        )
+        rc.record_rate_limit()
+        assert rc.rate == 5.0
+
+    def test_rate_does_not_exceed_max(self):
+        rc = AdaptiveRateController(
+            initial_rate=24.0, additive_increase=1.0, max_rate=25.0
+        )
+        rc.record_success()
+        assert rc.rate == 25.0
+        rc.record_success()
+        assert rc.rate == 25.0
+
+    def test_rate_does_not_go_below_min(self):
+        rc = AdaptiveRateController(
+            initial_rate=6.0, multiplicative_decrease=0.5, min_rate=5.0
+        )
+        rc.record_rate_limit()
+        # 6.0 * 0.5 = 3.0, but clamped to min 5.0
+        assert rc.rate == 5.0
+        rc.record_rate_limit()
+        # 5.0 * 0.5 = 2.5, clamped to 5.0
+        assert rc.rate == 5.0
+
+    def test_thread_safety(self):
+        rc = AdaptiveRateController(
+            initial_rate=10.0, additive_increase=0.1, max_rate=100.0, min_rate=1.0
+        )
+        errors = []
+
+        def call_success():
+            try:
+                for _ in range(100):
+                    rc.record_success()
+            except Exception as e:
+                errors.append(e)
+
+        def call_rate_limit():
+            try:
+                for _ in range(50):
+                    rc.record_rate_limit()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=call_success),
+            threading.Thread(target=call_success),
+            threading.Thread(target=call_rate_limit),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert rc.min_rate <= rc.rate <= rc.max_rate
+
+
+# --- fetch_reach_chunk retry tests ---
+
+
+def _make_fake_response(status_code, payload=None):
+    """Build a fake requests.Response-like object."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload if payload is not None else []
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_fetch_reach_chunk_retries_on_429_then_succeeds(monkeypatch):
+    """429 → 429 → 200 should succeed after 2 retries."""
+    responses = [
+        _make_fake_response(429),
+        _make_fake_response(429),
+        _make_fake_response(200, [{"flux": 1.0}]),
+    ]
+    call_count = {"n": 0}
+
+    def fake_get(url, headers, timeout):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return responses[idx]
+
+    monkeypatch.setattr(udl.requests, "get", fake_get)
+    monkeypatch.setattr(udl.time, "sleep", lambda s: None)  # skip actual sleeps
+
+    rc = AdaptiveRateController(initial_rate=10.0, min_rate=1.0)
+
+    dt, records = udl.fetch_reach_chunk(
+        "window-1",
+        "https://example.test/chunk1",
+        "Bearer token",
+        rate_controller=rc,
+        max_retries=5,
+    )
+
+    assert dt == "window-1"
+    assert records == [{"flux": 1.0}]
+    assert call_count["n"] == 3
+    # Rate should have decreased twice then increased once
+    assert rc.rate < 10.0
+
+
+def test_fetch_reach_chunk_raises_after_max_retries(monkeypatch):
+    """Persistent 429s should raise after max_retries."""
+    responses = [_make_fake_response(429) for _ in range(6)]
+    call_count = {"n": 0}
+
+    def fake_get(url, headers, timeout):
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return responses[idx]
+
+    monkeypatch.setattr(udl.requests, "get", fake_get)
+    monkeypatch.setattr(udl.time, "sleep", lambda s: None)
+
+    rc = AdaptiveRateController(initial_rate=10.0, min_rate=1.0)
+
+    with pytest.raises(Exception, match="HTTP 429"):
+        udl.fetch_reach_chunk(
+            "window-1",
+            "https://example.test/chunk1",
+            "Bearer token",
+            rate_controller=rc,
+            max_retries=5,
+        )
+
+    # 1 initial + 5 retries = 6 calls
+    assert call_count["n"] == 6
+
+
+def test_fetch_reach_chunk_works_without_rate_controller(monkeypatch):
+    """When rate_controller is None, fetch should work as before."""
+    resp = _make_fake_response(200, [{"flux": 2.5}])
+    monkeypatch.setattr(udl.requests, "get", lambda url, headers, timeout: resp)
+
+    dt, records = udl.fetch_reach_chunk(
+        "window-1",
+        "https://example.test/chunk1",
+        "Bearer token",
+        rate_controller=None,
+    )
+
+    assert dt == "window-1"
+    assert records == [{"flux": 2.5}]
+
+
+# --- Integration test: download with intermittent 429s ---
+
+
+def test_download_udl_reach_to_file_with_intermittent_429s(monkeypatch):
+    """Verify that download recovers from 429s and collects all chunks in order."""
+    fixed_now = Time("2026-01-01T00:30:00", format="isot", scale="utc")
+    monkeypatch.setattr(udl.Time, "now", staticmethod(lambda: fixed_now))
+
+    monkeypatch.setattr(
+        udl,
+        "get_reach_datetimelist",
+        lambda start_time, end_time, sensor_id: ["window-1", "window-2"],
+    )
+    monkeypatch.setattr(
+        udl,
+        "get_reach_urllist",
+        lambda dtlist, sensor_id, descriptor: {
+            "window-1": "https://example.test/chunk1",
+            "window-2": "https://example.test/chunk2",
+        },
+    )
+
+    # chunk1 returns 429 once then succeeds; chunk2 succeeds immediately
+    chunk1_calls = {"n": 0}
+
+    def fake_get(url, headers, timeout):
+        if "chunk1" in url:
+            chunk1_calls["n"] += 1
+            if chunk1_calls["n"] == 1:
+                return _make_fake_response(429)
+            return _make_fake_response(
+                200, [{"idSensor": "R1", "obTime": "t1", "flux": 1.0}]
+            )
+        return _make_fake_response(
+            200, [{"idSensor": "R1", "obTime": "t2", "flux": 2.0}]
+        )
+
+    monkeypatch.setattr(udl.requests, "get", fake_get)
+    monkeypatch.setattr(udl.time, "sleep", lambda s: None)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = udl.download_UDL_reach_to_file(
+            auth_token="Bearer test-token",
+            sensor_id="REACH-1",
+            descriptor="electron",
+            output_format="json",
+            delay_seconds=300,
+            window_seconds=1500,
+            output_dir=tmpdir,
+        )
+
+        assert output_path.exists()
+        with open(output_path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+
+        # Both chunks should be present, in order
+        assert len(payload) == 2
+        assert payload[0]["flux"] == 1.0
+        assert payload[1]["flux"] == 2.0

--- a/swxsoc_reach/tests/test_udl.py
+++ b/swxsoc_reach/tests/test_udl.py
@@ -583,3 +583,40 @@ def test_download_udl_reach_to_file_with_intermittent_429s(monkeypatch):
         assert len(payload) == 2
         assert payload[0]["flux"] == 1.0
         assert payload[1]["flux"] == 2.0
+
+
+def test_download_udl_reach_to_file_raises_on_empty_results(monkeypatch):
+    """Verify that an empty combined result raises ValueError."""
+    fixed_now = Time("2026-01-01T00:30:00", format="isot", scale="utc")
+    monkeypatch.setattr(udl.Time, "now", staticmethod(lambda: fixed_now))
+
+    monkeypatch.setattr(
+        udl,
+        "get_reach_datetimelist",
+        lambda start_time, end_time, sensor_id: ["window-1"],
+    )
+    monkeypatch.setattr(
+        udl,
+        "get_reach_urllist",
+        lambda dtlist, sensor_id, descriptor: {
+            "window-1": "https://example.test/chunk1",
+        },
+    )
+
+    monkeypatch.setattr(
+        udl.requests,
+        "get",
+        lambda url, headers, timeout: _make_fake_response(200, []),
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="No records returned"):
+            udl.download_UDL_reach_to_file(
+                auth_token="Bearer test-token",
+                sensor_id="ALL",
+                descriptor="electron",
+                output_format="json",
+                delay_seconds=300,
+                window_seconds=1500,
+                output_dir=tmpdir,
+            )


### PR DESCRIPTION
#### Added

- **Adaptive rate limiting for UDL downloads** — New `AdaptiveRateController` class in `swxsoc_reach.net.udl` implements thread-safe AIMD (Additive Increase / Multiplicative Decrease) throttling. Request rate ramps up after successes and backs off after HTTP 429 responses, preventing permanent failures in high-throughput environments like AWS Lambda.

- **Retry logic with exponential backoff** — `fetch_reach_chunk` now retries on HTTP 429 responses (up to 5 attempts by default) with exponential backoff and random jitter to avoid thundering-herd retries across concurrent threads.

- **Configurable rate controller parameters** — `download_UDL_reach_to_file` exposes five new optional keyword arguments (`initial_rate`, `additive_increase`, `multiplicative_decrease`, `min_rate`, `max_rate`) to tune the AIMD rate controller without code changes.

- **Empty-results validation** — `download_UDL_reach_to_file` now raises `ValueError` when no records are returned for the requested time window, preventing empty output files from being written.
