### PR TITLE
Create Historical Download & Processing CLI

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,8 +11,11 @@ API Reference
    swxsoc_reach
    swxsoc_reach.calibration.calibration
    swxsoc_reach.calibration.transform
+   swxsoc_reach.historical.download_orchestrator
+   swxsoc_reach.historical.telemetry
    swxsoc_reach.io.aws_db
    swxsoc_reach.io.file_tools
+   swxsoc_reach.net.auth
    swxsoc_reach.net.udl
    swxsoc_reach.util.schema
    swxsoc_reach.util.util

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,8 @@ API Reference
    swxsoc_reach.calibration.calibration
    swxsoc_reach.calibration.transform
    swxsoc_reach.historical.download_orchestrator
+   swxsoc_reach.historical.process_orchestrator
+   swxsoc_reach.historical.s3_upload
    swxsoc_reach.historical.telemetry
    swxsoc_reach.io.aws_db
    swxsoc_reach.io.file_tools

--- a/docs/user-guide/historical-download.rst
+++ b/docs/user-guide/historical-download.rst
@@ -1,0 +1,276 @@
+.. _historical-download:
+
+***************************
+Historical UDL Download CLI
+***************************
+
+The ``swxsoc_reach`` package ships a command-line tool for downloading
+REACH data from the Unified Data Library (UDL) over arbitrary historical
+date ranges. Unlike the scheduled Lambda path
+(:func:`~swxsoc_reach.net.udl.download_UDL_reach_to_file`), the CLI takes
+absolute UTC dates and writes one artifact per day, with append-only
+telemetry that supports safe restart and resume.
+
+The CLI is accessed via Python's ``-m`` module flag:
+
+.. code-block:: console
+
+   python -m swxsoc_reach download --help
+
+
+Quick start
+===========
+
+Download two days of data for a single sensor:
+
+.. code-block:: console
+
+   BASICAUTH="Basic <token>" python -m swxsoc_reach download \
+     --start-date 2026-01-01 \
+     --end-date   2026-01-02 \
+     --sensor-id  REACH-1 \
+     --output-dir ./out
+
+
+Resolving UDL credentials
+=========================
+
+The CLI obtains the UDL HTTP Basic auth credential at startup via
+:func:`swxsoc_reach.net.auth.resolve_udl_auth`. Resolution order:
+
+1. The ``BASICAUTH`` environment variable, if set, is used directly
+   (local-dev / pre-exported credential).
+2. Otherwise, if ``SECRET_ARN_UDL`` is set, the secret is fetched from
+   AWS Secrets Manager (using ``boto3``'s standard credential and
+   region resolution chain) and its ``basicauth`` JSON field is used.
+   The resolved value is also written back to ``os.environ['BASICAUTH']``.
+3. Otherwise the CLI exits with code ``2`` and a clear error message.
+
+``boto3`` is an optional dependency under the ``net`` extra:
+
+.. code-block:: console
+
+   pip install 'swxsoc_reach[net]'
+
+If you only ever use ``BASICAUTH`` (path 1), ``boto3`` is not required.
+
+
+Required arguments
+==================
+
+``--start-date YYYY-MM-DD``
+   Inclusive UTC start date.
+
+``--end-date YYYY-MM-DD``
+   Inclusive UTC end date.
+
+``--output-dir PATH``
+   Directory where per-day artifacts are written. Created if missing.
+
+
+Common options
+==============
+
+``--telemetry-file PATH``
+   Path to the append-only telemetry CSV. Defaults to
+   ``<output-dir>/download_telemetry.csv``.
+
+``--sensor-id ID``
+   REACH sensor identifier or ``ALL`` (default ``ALL``). Drives chunk
+   size in
+   :func:`~swxsoc_reach.net.udl.get_reach_datetimelist`:
+
+   - ``ALL`` → ~144 UDL requests/day (10-minute chunks).
+   - A specific sensor (e.g. ``REACH-1``) → ~4 UDL requests/day
+     (6-hour chunks).
+
+``--descriptor NAME``
+   UDL ``descriptor`` query value (default ``QUICKLOOK``).
+
+``--output-format {csv,json}``
+   Output serialization format (default ``csv``).
+
+``--retry-failed``
+   Re-attempt days whose latest telemetry status is ``FAILED``.
+   Without this flag, ``FAILED`` days are skipped on restart.
+
+``--limit-days N``
+   Cap the number of days actually attempted, counted from the first
+   day in the range that is not already ``DOWNLOADED`` with its CSV on
+   disk. Composes naturally with resume.
+
+``--dry-run``
+   Plan only: log per-day actions, write no telemetry, no network
+   calls. Does not require auth.
+
+``--aws-region REGION``
+   Optional AWS region override for the Secrets Manager lookup.
+
+``-v`` / ``-vv``
+   Increase logging verbosity.
+
+
+AIMD rate-controller flags
+==========================
+
+These knobs are forwarded to
+:func:`~swxsoc_reach.net.udl.download_UDL_reach_window` and tune the
+adaptive (Additive Increase / Multiplicative Decrease) request rate
+used by the per-day downloader. The defaults are the same as the
+Lambda path; an ``ALL`` historical backfill (≈144 req/day) typically
+benefits from raising ``--max-concurrent-requests`` and
+``--initial-rate``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Flag
+     - Default
+   * - ``--max-concurrent-requests``
+     - 4
+   * - ``--initial-rate``
+     - 5.0 req/s
+   * - ``--additive-increase``
+     - 1.0
+   * - ``--multiplicative-decrease``
+     - 0.5
+   * - ``--min-rate``
+     - 5.0 req/s
+   * - ``--max-rate``
+     - 25.0 req/s
+
+
+Restart and resume semantics
+============================
+
+The CLI is idempotent. On every run it loads the telemetry CSV and,
+for each day in the requested range, picks an action:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Latest prior status
+     - Artifact present?
+     - Action
+   * - *(no row)*
+     - n/a
+     - run
+   * - ``DOWNLOADED``
+     - yes
+     - skip (idempotent)
+   * - ``DOWNLOADED``
+     - no
+     - re-download
+   * - ``SKIPPED_NO_DATA``
+     - n/a
+     - skip (terminal)
+   * - ``FAILED``
+     - n/a
+     - skip, unless ``--retry-failed``
+   * - ``PENDING``
+     - n/a
+     - re-run (interrupted)
+
+
+Telemetry CSV schema
+====================
+
+One row is appended per attempt. Older rows for the same date are
+preserved; ``DownloadTelemetry.load_state`` returns the most-recent
+row per ``chunk_date_utc`` (file order breaks ties).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column
+     - Description
+   * - ``run_id``
+     - UUID4 stamped on every row written by a single CLI invocation.
+   * - ``chunk_date_utc``
+     - ``YYYY-MM-DD`` (UTC).
+   * - ``window_start_utc``
+     - ISO 8601 UTC, inclusive (``00:00:00`` of ``chunk_date_utc``).
+   * - ``window_end_utc``
+     - ISO 8601 UTC, exclusive (``window_start + 86400 s``).
+   * - ``status``
+     - ``PENDING`` | ``DOWNLOADED`` | ``SKIPPED_NO_DATA`` | ``FAILED``.
+   * - ``records_downloaded``
+     - Number of records in the written artifact.
+   * - ``expected_records``
+     - Per-sensor upper-bound baseline (``ALL`` → 1,105,920;
+       single sensor → 34,560).
+   * - ``availability_pct``
+     - ``records_downloaded / expected_records * 100``.
+   * - ``download_seconds``
+     - Wall-clock seconds for the per-day attempt.
+   * - ``csv_size_mb``
+     - Size of the written artifact in MiB.
+   * - ``csv_path``
+     - Absolute path of the written artifact (``DOWNLOADED`` only).
+   * - ``sensor_id``, ``descriptor``, ``output_format``
+     - Echo of the run inputs.
+   * - ``error_type``, ``error_message``
+     - Populated on ``FAILED`` (and ``error_message`` on
+       ``SKIPPED_NO_DATA``).
+   * - ``started_at_utc``, ``finished_at_utc``
+     - ISO 8601 UTC timestamps for the attempt.
+
+
+Exit codes
+==========
+
+- ``0`` — every planned day succeeded or was a known skip.
+- ``1`` — at least one day ended in ``FAILED``.
+- ``2`` — usage / configuration error (auth resolution failed,
+  inverted date range, etc.).
+
+
+Running via Docker
+==================
+
+The team's existing Docker image ships ``swxsoc_reach`` pre-installed.
+Override the entrypoint to invoke the CLI:
+
+.. code-block:: console
+
+   docker run --rm -it \
+     -e SECRET_ARN_UDL=$SECRET_ARN_UDL \
+     -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+     -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
+     -v /local/output:/output_dir \
+     --entrypoint python <team-image>:latest \
+     -m swxsoc_reach download \
+       --start-date 2026-01-01 \
+       --end-date   2026-01-31 \
+       --sensor-id  ALL \
+       --output-dir /output_dir
+
+
+Operator runbook: interrupted runs
+==================================
+
+If a multi-day run is interrupted (Ctrl-C, container killed, network
+loss):
+
+1. The telemetry CSV in ``--output-dir`` is consistent on disk
+   (``fsync`` after every row).
+2. Days that were mid-flight at interrupt time will have a ``PENDING``
+   row as their latest entry — these will be **re-run** on the next
+   invocation.
+3. Days that completed normally have a ``DOWNLOADED`` row plus their
+   artifact on disk and will be **skipped** on the next invocation.
+4. To pick up where you left off, simply re-run the same command.
+   Add ``--retry-failed`` if you also want to re-attempt days that
+   ended in ``FAILED``.
+
+To inspect progress without running anything, use ``--dry-run``:
+
+.. code-block:: console
+
+   python -m swxsoc_reach download \
+     --start-date 2026-01-01 --end-date 2026-01-31 \
+     --output-dir ./out --dry-run -v

--- a/docs/user-guide/historical-download.rst
+++ b/docs/user-guide/historical-download.rst
@@ -169,7 +169,7 @@ for each day in the requested range, picks an action:
    * - ``FAILED``
      - n/a
      - skip, unless ``--retry-failed``
-   * - ``PENDING``
+   * - ``DOWNLOAD_PENDING``
      - n/a
      - re-run (interrupted)
 
@@ -178,7 +178,7 @@ Telemetry CSV schema
 ====================
 
 One row is appended per attempt. Older rows for the same date are
-preserved; ``DownloadTelemetry.load_state`` returns the most-recent
+preserved; ``HistoricalTelemetry.load_state`` returns the most-recent
 row per ``chunk_date_utc`` (file order breaks ties).
 
 .. list-table::
@@ -196,7 +196,11 @@ row per ``chunk_date_utc`` (file order breaks ties).
    * - ``window_end_utc``
      - ISO 8601 UTC, exclusive (``window_start + 86400 s``).
    * - ``status``
-     - ``PENDING`` | ``DOWNLOADED`` | ``SKIPPED_NO_DATA`` | ``FAILED``.
+     - ``DOWNLOAD_PENDING`` | ``DOWNLOADED`` | ``SKIPPED_NO_DATA`` |
+       ``FAILED``. Phase 2 (process / upload) writes additional
+       statuses (``PROCESS_PENDING``, ``PROCESSED``,
+       ``UPLOAD_PENDING``, ``UPLOADED``, ``SKIPPED_NO_INPUT``) to the
+       same file — see :ref:`historical-process`.
    * - ``records_downloaded``
      - Number of records in the written artifact.
    * - ``expected_records``
@@ -258,9 +262,9 @@ loss):
 
 1. The telemetry CSV in ``--output-dir`` is consistent on disk
    (``fsync`` after every row).
-2. Days that were mid-flight at interrupt time will have a ``PENDING``
-   row as their latest entry — these will be **re-run** on the next
-   invocation.
+2. Days that were mid-flight at interrupt time will have a
+   ``DOWNLOAD_PENDING`` row as their latest entry — these will be
+   **re-run** on the next invocation.
 3. Days that completed normally have a ``DOWNLOADED`` row plus their
    artifact on disk and will be **skipped** on the next invocation.
 4. To pick up where you left off, simply re-run the same command.

--- a/docs/user-guide/historical-process.rst
+++ b/docs/user-guide/historical-process.rst
@@ -1,0 +1,176 @@
+.. _historical-process:
+
+***********************************
+Historical CSV → CDF Processing CLI
+***********************************
+
+The ``process`` subcommand of ``python -m swxsoc_reach`` converts the
+per-day UDL CSV files produced by :ref:`historical-download` into
+CDFs, with optional S3 upload. It is sequential at the day level and
+resumable: rerunning the same date range only re-attempts days that
+are not already complete according to the shared telemetry CSV.
+
+This is Phase 2 of the historical reprocessing toolchain. Phase 1
+(download) is documented at :ref:`historical-download`.
+
+Quick start
+===========
+
+.. code-block:: shell
+
+    # Phase 1: download the day's CSV
+    python -m swxsoc_reach download \
+        --start-date 2026-01-01 --end-date 2026-01-01 \
+        --sensor-id REACH-1 --output-dir ./out
+
+    # Phase 2 (local-only): produce a CDF
+    python -m swxsoc_reach process \
+        --start-date 2026-01-01 --end-date 2026-01-01 \
+        --sensor-id REACH-1 \
+        --input-dir ./out --output-dir ./out_cdf
+
+    # Phase 2 (with S3 upload): also upload to S3
+    python -m swxsoc_reach process \
+        --start-date 2026-01-01 --end-date 2026-01-01 \
+        --sensor-id REACH-1 \
+        --input-dir ./out --output-dir ./out_cdf \
+        --upload-to-s3 --s3-bucket dev-swxsoc-pipeline-incoming
+
+CLI reference
+=============
+
+Required arguments
+------------------
+
+- ``--start-date YYYY-MM-DD`` — inclusive UTC start date.
+- ``--end-date YYYY-MM-DD`` — inclusive UTC end date.
+- ``--input-dir PATH`` — directory holding Phase 1 download
+  artifacts. The orchestrator globs this directory for filenames
+  matching each UTC day; days with no matching file are recorded as
+  ``SKIPPED_NO_INPUT``.
+- ``--output-dir PATH`` — directory where CDF files are written.
+
+Optional arguments
+------------------
+
+- ``--telemetry-file PATH`` — append-only telemetry CSV. Defaults to
+  ``<input-dir>/download_telemetry.csv`` (the same file Phase 1
+  writes). Use this only if you keep telemetry separate from the
+  download artifacts.
+- ``--sensor-id`` — REACH sensor identifier or ``ALL`` (default).
+  Drives the input filename pattern.
+- ``--descriptor`` — UDL descriptor (default ``QUICKLOOK``).
+- ``--output-format`` — input serialization format (default ``csv``).
+- ``--retry-failed`` — re-attempt days whose latest telemetry status
+  is ``FAILED``.
+- ``--limit-days N`` — cap attempted days, counted from the first
+  day in the range that is not already complete.
+- ``--dry-run`` — plan only: log per-day actions, write no telemetry,
+  do no work.
+- ``-v`` / ``-vv`` — increase logging verbosity.
+
+S3 upload arguments
+-------------------
+
+- ``--upload-to-s3`` — when set, uploads each successful CDF to S3
+  via :func:`sdc_aws_utils.aws.push_science_file`. ``UPLOADED`` is the
+  terminal status. Without this flag, ``PROCESSED`` is terminal.
+- ``--s3-bucket`` — destination bucket (required iff
+  ``--upload-to-s3`` is set).
+- ``--aws-region`` — optional AWS region. Defaults to ``boto3``'s
+  standard region resolution chain.
+
+Optional dependencies
+=====================
+
+S3 upload requires the optional ``net`` extra:
+
+.. code-block:: shell
+
+    pip install 'swxsoc_reach[net]'
+
+This installs ``boto3`` and ``sdc_aws_utils``. Without these, calling
+``--upload-to-s3`` raises ``RuntimeError`` with an install hint.
+
+Status lifecycle
+================
+
+Phase 2 introduces stage-prefixed pending statuses so the row
+indicates which stage was interrupted:
+
+- ``PROCESS_PENDING`` — process_file invocation in progress.
+- ``PROCESSED`` — CDF written to disk. Terminal in local-only mode.
+- ``UPLOAD_PENDING`` — S3 upload in progress.
+- ``UPLOADED`` — CDF successfully uploaded. Terminal in upload mode.
+- ``SKIPPED_NO_INPUT`` — no matching CSV for the day in
+  ``--input-dir``. Re-runnable: the day is re-attempted if the input
+  later appears.
+
+Phase 1 statuses (``DOWNLOAD_PENDING``, ``DOWNLOADED``,
+``SKIPPED_NO_DATA``) are treated as "no prior process-stage row" by
+the resume logic.
+
+Telemetry schema
+================
+
+Phase 2 extends the Phase 1 download telemetry CSV with these
+columns (all default to ``""`` for older rows):
+
+- ``process_seconds`` — wall-clock seconds spent in
+  :func:`process_file`.
+- ``cdf_size_mb`` — size of the produced CDF in megabytes.
+- ``cdf_path`` — local path of the CDF.
+- ``upload_seconds`` — wall-clock seconds spent in the S3 upload.
+- ``s3_bucket`` — destination bucket reported on a successful
+  upload.
+- ``s3_key`` — S3 key returned by
+  :func:`sdc_aws_utils.aws.push_science_file`.
+
+Restart semantics
+=================
+
+Resume rules per UTC day, based on the most-recent telemetry row:
+
+- ``UPLOADED`` → skip (terminal).
+- ``PROCESSED`` + CDF on disk + upload mode → upload only.
+- ``PROCESSED`` + CDF on disk + local-only mode → skip (terminal).
+- ``PROCESSED`` + CDF missing → re-process from CSV.
+- ``UPLOAD_PENDING`` + CDF on disk → upload only.
+- ``UPLOAD_PENDING`` + CDF missing → re-process from CSV.
+- ``PROCESS_PENDING`` → re-process from CSV.
+- ``FAILED`` → skip unless ``--retry-failed``.
+- ``SKIPPED_NO_INPUT`` → re-attempt if CSV is now present.
+- Phase 1 statuses → re-process from CSV.
+
+Operator runbook
+================
+
+Process succeeded but upload failed
+   The day's row sequence ends in ``UPLOAD_PENDING`` then ``FAILED``
+   with a populated ``error_type`` / ``error_message``. The CDF is
+   on disk in ``--output-dir``. Resolve the cause (creds, bucket
+   access, etc.), then rerun with ``--retry-failed``: the
+   orchestrator detects the existing CDF and uploads only.
+
+Process failed mid-day
+   The day's row sequence ends in ``PROCESS_PENDING`` then
+   ``FAILED``. Inspect the error fields, fix the underlying issue,
+   then rerun with ``--retry-failed``.
+
+CDF accidentally deleted
+   Delete the CDF from ``--output-dir`` and rerun without
+   ``--retry-failed``. The orchestrator detects the missing CDF and
+   re-processes from the CSV automatically.
+
+Notes & caveats
+===============
+
+- ``process_file`` writes to ``Path.cwd()`` when
+  ``LAMBDA_ENVIRONMENT`` is unset, which is always the case for a
+  historical local run. The orchestrator chdir's into
+  ``--output-dir`` for the duration of each call and restores the
+  prior cwd in ``finally``.
+- When the same telemetry CSV is shared with Phase 1 (recommended),
+  rerunning the ``download`` subcommand after ``process`` continues
+  to behave correctly because ``download`` only consults Phase 1
+  statuses for resume.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -13,3 +13,4 @@ For more details checkout the :ref:`reference`.
    overview
    logger
    customization
+   historical-download

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -14,3 +14,4 @@ For more details checkout the :ref:`reference`.
    logger
    customization
    historical-download
+   historical-process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
 
 net = [
   'boto3',
+  'sdc_aws_utils @ git+https://github.com/swxsoc/sdc_aws_utils.git@main',
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-  "swxsoc_reach[docs, test, style]"
+  "swxsoc_reach[docs, test, style, net]"
+]
+
+net = [
+  'boto3',
 ]
 
 docs = [

--- a/swxsoc_reach/__main__.py
+++ b/swxsoc_reach/__main__.py
@@ -104,7 +104,7 @@ def _add_download_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
     dl.add_argument(
         "--descriptor",
-        choices=["QUICKLOOK", "PRELIMINARY"],
+        choices=["QUICKLOOK", "PROVISIONAL"],
         default="QUICKLOOK",
         help="UDL descriptor query value (default: QUICKLOOK).",
     )

--- a/swxsoc_reach/__main__.py
+++ b/swxsoc_reach/__main__.py
@@ -1,0 +1,247 @@
+"""Command-line entry point for ``python -m swxsoc_reach``.
+
+Currently exposes a single ``download`` subcommand that drives the
+historical UDL download orchestrator. The argparse layout uses
+*subparsers* so the future Phase 2 ``process`` subcommand can be added
+without changing existing flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import Sequence
+
+from swxsoc_reach import log
+from swxsoc_reach.historical.download_orchestrator import (
+    DownloadRunConfig,
+    DownloadRunSummary,
+    run_download,
+)
+from swxsoc_reach.net.auth import resolve_udl_auth
+
+
+def _parse_iso_date(value: str) -> date:
+    """argparse type for ``YYYY-MM-DD`` UTC dates."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"{value!r} is not a valid YYYY-MM-DD date"
+        ) from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m swxsoc_reach",
+        description=(
+            "swxsoc_reach command-line tools. Today only the 'download' "
+            "subcommand is implemented; 'process' is reserved for a "
+            "future phase."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    dl = subparsers.add_parser(
+        "download",
+        help="Historical UDL download over an inclusive UTC date range.",
+        description=(
+            "Drive a per-day UDL download over [start-date, end-date] UTC, "
+            "inclusive. Each day produces one CSV/JSON artifact under "
+            "--output-dir plus telemetry rows in --telemetry-file. Reruns "
+            "are idempotent: days already DOWNLOADED with their artifact "
+            "on disk are skipped. Per-day request count: sensor_id=ALL "
+            "uses ~144 UDL requests/day (10-min chunks); a specific "
+            "sensor uses ~4/day (6-hour chunks)."
+        ),
+    )
+
+    dl.add_argument(
+        "--start-date",
+        required=True,
+        type=_parse_iso_date,
+        help="Inclusive UTC start date (YYYY-MM-DD).",
+    )
+    dl.add_argument(
+        "--end-date",
+        required=True,
+        type=_parse_iso_date,
+        help="Inclusive UTC end date (YYYY-MM-DD).",
+    )
+    dl.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory where per-day artifacts are written.",
+    )
+    dl.add_argument(
+        "--telemetry-file",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the append-only telemetry CSV. "
+            "Defaults to <output-dir>/download_telemetry.csv."
+        ),
+    )
+    dl.add_argument(
+        "--sensor-id",
+        default="ALL",
+        help="REACH sensor identifier or 'ALL' (default: ALL).",
+    )
+    dl.add_argument(
+        "--descriptor",
+        choices=["QUICKLOOK", "PRELIMINARY"],
+        default="QUICKLOOK",
+        help="UDL descriptor query value (default: QUICKLOOK).",
+    )
+    dl.add_argument(
+        "--output-format",
+        choices=["csv", "json"],
+        default="csv",
+        help="Output serialization format (default: csv).",
+    )
+    dl.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Re-attempt days whose latest telemetry status is FAILED.",
+    )
+    dl.add_argument(
+        "--limit-days",
+        type=int,
+        default=None,
+        help=(
+            "Cap the number of days actually attempted, counted from the "
+            "first day in the range that is not already DOWNLOADED."
+        ),
+    )
+    dl.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan only: log per-day actions, write no telemetry, no network.",
+    )
+    dl.add_argument(
+        "--aws-region",
+        default=None,
+        help=(
+            "Optional AWS region for the Secrets Manager lookup. Defaults "
+            "to boto3's standard region resolution chain."
+        ),
+    )
+    dl.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (-v INFO, -vv DEBUG).",
+    )
+
+    aimd = dl.add_argument_group(
+        "AIMD rate controller",
+        "Tuning for the per-day downloader's adaptive request rate.",
+    )
+    aimd.add_argument("--max-concurrent-requests", type=int, default=4)
+    aimd.add_argument("--initial-rate", type=float, default=5.0)
+    aimd.add_argument("--additive-increase", type=float, default=1.0)
+    aimd.add_argument("--multiplicative-decrease", type=float, default=0.5)
+    aimd.add_argument("--min-rate", type=float, default=5.0)
+    aimd.add_argument("--max-rate", type=float, default=25.0)
+
+    return parser
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Map -v/-vv to logging levels on the package logger."""
+    level = logging.WARNING
+    if verbosity == 1:
+        level = logging.INFO
+    elif verbosity >= 2:
+        level = logging.DEBUG
+    log.setLevel(level)
+
+
+def _config_from_args(args: argparse.Namespace, auth_token: str) -> DownloadRunConfig:
+    telemetry_path = (
+        args.telemetry_file
+        if args.telemetry_file is not None
+        else args.output_dir / "download_telemetry.csv"
+    )
+    return DownloadRunConfig(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        output_dir=args.output_dir,
+        telemetry_path=telemetry_path,
+        sensor_id=args.sensor_id,
+        descriptor=args.descriptor,
+        output_format=args.output_format,
+        retry_failed=args.retry_failed,
+        limit_days=args.limit_days,
+        dry_run=args.dry_run,
+        auth_token=auth_token,
+        max_concurrent_requests=args.max_concurrent_requests,
+        initial_rate=args.initial_rate,
+        additive_increase=args.additive_increase,
+        multiplicative_decrease=args.multiplicative_decrease,
+        min_rate=args.min_rate,
+        max_rate=args.max_rate,
+    )
+
+
+def _log_summary(summary: DownloadRunSummary) -> None:
+    log.info(
+        f"Run {summary.run_id} complete: "
+        f"planned={summary.days_planned} "
+        f"downloaded={summary.days_downloaded} "
+        f"skipped_existing={summary.days_skipped_existing} "
+        f"skipped_no_data={summary.days_skipped_no_data} "
+        f"failed={summary.days_failed}"
+    )
+
+
+def _run_download_command(args: argparse.Namespace) -> int:
+    if args.dry_run:
+        # Dry-run plans only; don't require auth.
+        auth_token = ""
+    else:
+        try:
+            auth_token = resolve_udl_auth(region_name=args.aws_region)
+        except RuntimeError as exc:
+            log.error(f"UDL auth resolution failed: {exc}")
+            return 2
+
+    if args.end_date < args.start_date:
+        log.error(
+            f"--end-date ({args.end_date.isoformat()}) must be on or after "
+            f"--start-date ({args.start_date.isoformat()})."
+        )
+        return 2
+
+    config = _config_from_args(args, auth_token)
+    summary = run_download(config)
+    _log_summary(summary)
+    # Exit non-zero if any day failed so operators can detect it from
+    # shell / CI without parsing logs.
+    return 1 if summary.days_failed > 0 else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for ``python -m swxsoc_reach``.
+
+    Returns the process exit code: ``0`` on full success, ``1`` if any
+    day ended in ``FAILED``, ``2`` for usage / config errors.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    _configure_logging(args.verbose)
+
+    if args.command == "download":
+        return _run_download_command(args)
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2  # unreachable; parser.error exits
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/swxsoc_reach/__main__.py
+++ b/swxsoc_reach/__main__.py
@@ -1,9 +1,12 @@
 """Command-line entry point for ``python -m swxsoc_reach``.
 
-Currently exposes a single ``download`` subcommand that drives the
-historical UDL download orchestrator. The argparse layout uses
-*subparsers* so the future Phase 2 ``process`` subcommand can be added
-without changing existing flags.
+Exposes two subcommands:
+
+- ``download`` — historical UDL download orchestrator
+- ``process``  — historical CSV → CDF processor with optional S3 upload.
+
+The argparse layout uses *subparsers* so future subcommands can be
+added without changing existing flags.
 """
 
 from __future__ import annotations
@@ -18,8 +21,11 @@ from typing import Sequence
 from swxsoc_reach import log
 from swxsoc_reach.historical.download_orchestrator import (
     DownloadRunConfig,
-    DownloadRunSummary,
     run_download,
+)
+from swxsoc_reach.historical.process_orchestrator import (
+    ProcessRunConfig,
+    run_process,
 )
 from swxsoc_reach.net.auth import resolve_udl_auth
 
@@ -38,13 +44,18 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m swxsoc_reach",
         description=(
-            "swxsoc_reach command-line tools. Today only the 'download' "
-            "subcommand is implemented; 'process' is reserved for a "
-            "future phase."
+            "swxsoc_reach command-line tools: 'download' drives the "
+            "historical UDL downloader, 'process' converts the resulting "
+            "CSVs into CDFs and (optionally) uploads them to S3."
         ),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_download_subparser(subparsers)
+    _add_process_subparser(subparsers)
+    return parser
 
+
+def _add_download_subparser(subparsers: argparse._SubParsersAction) -> None:
     dl = subparsers.add_parser(
         "download",
         help="Historical UDL download over an inclusive UTC date range.",
@@ -149,7 +160,117 @@ def _build_parser() -> argparse.ArgumentParser:
     aimd.add_argument("--min-rate", type=float, default=5.0)
     aimd.add_argument("--max-rate", type=float, default=25.0)
 
-    return parser
+
+def _add_process_subparser(subparsers: argparse._SubParsersAction) -> None:
+    pr = subparsers.add_parser(
+        "process",
+        help="Historical CSV → CDF processor (with optional S3 upload).",
+        description=(
+            "Convert per-day UDL CSVs (produced by 'download') into CDFs "
+            "and optionally upload them to S3 via sdc_aws_utils. Inputs "
+            "are discovered by globbing --input-dir for filenames "
+            "matching each UTC day in [start-date, end-date]. Reuses the "
+            "Phase 1 telemetry CSV (extended schema) so the full "
+            "download → process → upload lifecycle is in one file."
+        ),
+    )
+    pr.add_argument(
+        "--start-date",
+        required=True,
+        type=_parse_iso_date,
+        help="Inclusive UTC start date (YYYY-MM-DD).",
+    )
+    pr.add_argument(
+        "--end-date",
+        required=True,
+        type=_parse_iso_date,
+        help="Inclusive UTC end date (YYYY-MM-DD).",
+    )
+    pr.add_argument(
+        "--input-dir",
+        required=True,
+        type=Path,
+        help="Directory holding Phase 1 download artifacts (CSV/JSON).",
+    )
+    pr.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory where CDF files are written.",
+    )
+    pr.add_argument(
+        "--telemetry-file",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the append-only telemetry CSV. Defaults to "
+            "<input-dir>/download_telemetry.csv (the same file Phase 1 "
+            "writes)."
+        ),
+    )
+    pr.add_argument(
+        "--sensor-id",
+        default="ALL",
+        help="REACH sensor identifier or 'ALL' (default: ALL).",
+    )
+    pr.add_argument(
+        "--descriptor",
+        choices=["QUICKLOOK", "PRELIMINARY"],
+        default="QUICKLOOK",
+        help="UDL descriptor query value (default: QUICKLOOK).",
+    )
+    pr.add_argument(
+        "--output-format",
+        choices=["csv", "json"],
+        default="csv",
+        help="Input serialization format on disk (default: csv).",
+    )
+    pr.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Re-attempt days whose latest telemetry status is FAILED.",
+    )
+    pr.add_argument(
+        "--limit-days",
+        type=int,
+        default=None,
+        help=(
+            "Cap on attempted days, counted from the first day in the "
+            "range that is not already complete."
+        ),
+    )
+    pr.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan only: log per-day actions, write no telemetry, no work.",
+    )
+    pr.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (-v INFO, -vv DEBUG).",
+    )
+
+    s3 = pr.add_argument_group(
+        "S3 upload",
+        "Optional upload of the produced CDF to S3 via sdc_aws_utils.",
+    )
+    s3.add_argument(
+        "--upload-to-s3",
+        action="store_true",
+        help="Upload each successful CDF to S3 (requires --s3-bucket).",
+    )
+    s3.add_argument(
+        "--s3-bucket",
+        default=None,
+        help="Destination S3 bucket name (required iff --upload-to-s3).",
+    )
+    s3.add_argument(
+        "--aws-region",
+        default=None,
+        help="Optional AWS region. Defaults to boto3's standard chain.",
+    )
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -162,7 +283,9 @@ def _configure_logging(verbosity: int) -> None:
     log.setLevel(level)
 
 
-def _config_from_args(args: argparse.Namespace, auth_token: str) -> DownloadRunConfig:
+def _download_config_from_args(
+    args: argparse.Namespace, auth_token: str
+) -> DownloadRunConfig:
     telemetry_path = (
         args.telemetry_file
         if args.telemetry_file is not None
@@ -189,17 +312,6 @@ def _config_from_args(args: argparse.Namespace, auth_token: str) -> DownloadRunC
     )
 
 
-def _log_summary(summary: DownloadRunSummary) -> None:
-    log.info(
-        f"Run {summary.run_id} complete: "
-        f"planned={summary.days_planned} "
-        f"downloaded={summary.days_downloaded} "
-        f"skipped_existing={summary.days_skipped_existing} "
-        f"skipped_no_data={summary.days_skipped_no_data} "
-        f"failed={summary.days_failed}"
-    )
-
-
 def _run_download_command(args: argparse.Namespace) -> int:
     if args.dry_run:
         # Dry-run plans only; don't require auth.
@@ -218,11 +330,67 @@ def _run_download_command(args: argparse.Namespace) -> int:
         )
         return 2
 
-    config = _config_from_args(args, auth_token)
+    config = _download_config_from_args(args, auth_token)
     summary = run_download(config)
-    _log_summary(summary)
+    log.info(
+        f"Run {summary.run_id} complete: "
+        f"planned={summary.days_planned} "
+        f"downloaded={summary.days_downloaded} "
+        f"skipped_existing={summary.days_skipped_existing} "
+        f"skipped_no_data={summary.days_skipped_no_data} "
+        f"failed={summary.days_failed}"
+    )
     # Exit non-zero if any day failed so operators can detect it from
     # shell / CI without parsing logs.
+    return 1 if summary.days_failed > 0 else 0
+
+
+def _process_config_from_args(args: argparse.Namespace) -> ProcessRunConfig:
+    telemetry_path = (
+        args.telemetry_file
+        if args.telemetry_file is not None
+        else args.input_dir / "download_telemetry.csv"
+    )
+    return ProcessRunConfig(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        input_dir=args.input_dir,
+        output_dir=args.output_dir,
+        telemetry_path=telemetry_path,
+        sensor_id=args.sensor_id,
+        descriptor=args.descriptor,
+        output_format=args.output_format,
+        retry_failed=args.retry_failed,
+        limit_days=args.limit_days,
+        dry_run=args.dry_run,
+        upload_to_s3=args.upload_to_s3,
+        s3_bucket=args.s3_bucket,
+    )
+
+
+def _run_process_command(
+    args: argparse.Namespace, parser: argparse.ArgumentParser
+) -> int:
+    if args.upload_to_s3 and not args.s3_bucket:
+        parser.error("--upload-to-s3 requires --s3-bucket")
+    if args.end_date < args.start_date:
+        log.error(
+            f"--end-date ({args.end_date.isoformat()}) must be on or after "
+            f"--start-date ({args.start_date.isoformat()})."
+        )
+        return 2
+
+    config = _process_config_from_args(args)
+    summary = run_process(config)
+    log.info(
+        f"Run {summary.run_id} complete: "
+        f"planned={summary.days_planned} "
+        f"processed={summary.days_processed} "
+        f"uploaded={summary.days_uploaded} "
+        f"skipped_existing={summary.days_skipped_existing} "
+        f"skipped_no_input={summary.days_skipped_no_input} "
+        f"failed={summary.days_failed}"
+    )
     return 1 if summary.days_failed > 0 else 0
 
 
@@ -238,6 +406,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "download":
         return _run_download_command(args)
+    if args.command == "process":
+        return _run_process_command(args, parser)
 
     parser.error(f"Unknown command: {args.command}")
     return 2  # unreachable; parser.error exits

--- a/swxsoc_reach/calibration/transform.py
+++ b/swxsoc_reach/calibration/transform.py
@@ -252,8 +252,9 @@ def build_swxdata(
        in astropy's recursive ISO-8601 parser for large arrays.
     4. **Pre-compute per-sensor groupby** on a sensor-deduplicated view of
        the data for efficient scalar-column extraction.
-    5. **Build variable dict** of :class:`~astropy.nddata.NDData` arrays
-       (observations, attitude, quality, sensor-position, and label variables).
+     5. **Build variable dict** of :class:`~astropy.nddata.NDData` arrays
+         (dose-rate cube, geolocation/quality arrays, sensor-position arrays,
+         and label/ID metadata variables).
     6. **Seed global attributes** from :class:`~swxsoc_reach.util.schema.REACHDataSchema`
        defaults, then overlay *version* and any caller-supplied *global_attrs*.
     7. **Assemble and return** a :class:`~swxsoc.swxdata.SWXData` instance
@@ -261,23 +262,24 @@ def build_swxdata(
 
     The returned :class:`~swxsoc.swxdata.SWXData` contains:
 
-    ========================  ==========================================
-    Variable                  Shape
-    ========================  ==========================================
-    ``Epoch``                 ``(n_times,)``
-    ``Epoch_label``           ``(n_times,)``
-    ``sensor_ids``            ``(n_sensors,)``
-    ``observation_flavors``   ``(n_sensors, n_flavors_max)``
-    ``Flavor_label``          ``(n_flavors_max,)``
-    ``observations``          ``(n_times, n_sensors, n_flavors_max)``
-    ``lat``                   ``(n_times, n_sensors)``
-    ``lon``                   ``(n_times, n_sensors)``
-    ``alt``                   ``(n_times, n_sensors)``
-    ``obQuality``             ``(n_times, n_sensors)``
-    ``senPos0``               ``(n_times, n_sensors)``
-    ``senPos1``               ``(n_times, n_sensors)``
-    ``senPos2``               ``(n_times, n_sensors)``
-    ========================  ==========================================
+    ===========================  ==========================================
+    Variable                     Shape
+    ===========================  ==========================================
+    ``Epoch``                    ``(n_times,)``
+    ``sensor_labels``            ``(n_sensors,)``
+    ``sensor_ids``               ``(n_sensors,)``
+    ``dosimeter_flavor_labels``  ``(n_flavors_max,)``
+    ``dosimeter_flavor_ids``     ``(n_flavors_max,)``
+    ``dosimeter_flavors``        ``(n_sensors, n_flavors_max)``
+    ``dose_rate``                ``(n_times, n_sensors, n_flavors_max)``
+    ``lat``                      ``(n_times, n_sensors)``
+    ``lon``                      ``(n_times, n_sensors)``
+    ``alt``                      ``(n_times, n_sensors)``
+    ``obQuality``                ``(n_times, n_sensors)``
+    ``sensor_position_x``        ``(n_times, n_sensors)``
+    ``sensor_position_y``        ``(n_times, n_sensors)``
+    ``sensor_position_z``        ``(n_times, n_sensors)``
+    ===========================  ==========================================
 
     Parameters
     ----------

--- a/swxsoc_reach/historical/__init__.py
+++ b/swxsoc_reach/historical/__init__.py
@@ -1,0 +1,7 @@
+"""Historical reprocessing utilities for ``swxsoc_reach``.
+
+This sub-package hosts the pieces that drive multi-day historical UDL
+downloads and re-processing. It is intentionally separate from
+:mod:`swxsoc_reach.net.udl`, which holds the per-window download
+machinery reused here.
+"""

--- a/swxsoc_reach/historical/_dates.py
+++ b/swxsoc_reach/historical/_dates.py
@@ -1,0 +1,24 @@
+"""Shared helpers for the historical orchestrators."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Iterable
+
+
+def iter_dates(start: date, end: date) -> Iterable[date]:
+    """Yield each UTC date in ``[start, end]`` inclusive.
+
+    Raises
+    ------
+    ValueError
+        If ``end`` is before ``start``.
+    """
+    if end < start:
+        raise ValueError(
+            f"end_date {end.isoformat()} must be >= start_date {start.isoformat()}"
+        )
+    current = start
+    while current <= end:
+        yield current
+        current = current + timedelta(days=1)

--- a/swxsoc_reach/historical/download_orchestrator.py
+++ b/swxsoc_reach/historical/download_orchestrator.py
@@ -2,7 +2,7 @@
 
 Drives :func:`swxsoc_reach.net.udl.download_UDL_reach_window` over an
 inclusive UTC date range, recording one or more rows per day in a
-:class:`~swxsoc_reach.historical.telemetry.DownloadTelemetry` CSV. Days
+:class:`~swxsoc_reach.historical.telemetry.HistoricalTelemetry` CSV. Days
 that already completed (per telemetry + on-disk artifact) are skipped,
 so reruns are idempotent and resumable.
 
@@ -19,16 +19,17 @@ import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable
 
 from astropy.time import Time
 
 from swxsoc_reach import log
+from swxsoc_reach.historical._dates import iter_dates as _iter_dates
 from swxsoc_reach.historical.telemetry import (
-    DownloadTelemetry,
+    HistoricalTelemetry,
+    STATUS_DOWNLOAD_PENDING,
     STATUS_DOWNLOADED,
     STATUS_FAILED,
-    STATUS_PENDING,
     STATUS_SKIPPED_NO_DATA,
     TelemetryRow,
     utcnow_iso,
@@ -168,18 +169,6 @@ def _expected_records(sensor_id: str) -> int:
     return EXPECTED_RECORDS_SINGLE
 
 
-def _iter_dates(start: date, end: date) -> Iterable[date]:
-    """Yield each UTC date in ``[start, end]`` inclusive."""
-    if end < start:
-        raise ValueError(
-            f"end_date {end.isoformat()} must be >= start_date {start.isoformat()}"
-        )
-    current = start
-    while current <= end:
-        yield current
-        current = current + timedelta(days=1)
-
-
 def _day_window(d: date) -> tuple[Time, Time, str, str]:
     """Return (start_time, end_time, start_iso, end_iso) for a UTC day.
 
@@ -210,7 +199,7 @@ def _decide_action(
     - prior ``DOWNLOADED`` and CSV missing → ``run`` (re-download)
     - prior ``SKIPPED_NO_DATA`` → ``skip_terminal``
     - prior ``FAILED`` → ``skip_failed`` unless ``retry_failed`` then ``run``
-    - prior ``PENDING`` (interrupted) → ``run``
+    - prior ``DOWNLOAD_PENDING`` (interrupted) → ``run``
     """
     if prior is None:
         return "run"
@@ -223,7 +212,7 @@ def _decide_action(
         return "skip_terminal"
     if prior.status == STATUS_FAILED:
         return "run" if retry_failed else "skip_failed"
-    # PENDING or unknown → re-run.
+    # DOWNLOAD_PENDING or unknown → re-run.
     return "run"
 
 
@@ -231,7 +220,7 @@ def run_download(
     config: DownloadRunConfig,
     *,
     download_fn: Callable[..., Path] | None = None,
-    telemetry: DownloadTelemetry | None = None,
+    telemetry: HistoricalTelemetry | None = None,
 ) -> DownloadRunSummary:
     """Run the historical UDL download orchestrator.
 
@@ -243,7 +232,7 @@ def run_download(
     2. **Load prior state.** Read the telemetry CSV at
        ``config.telemetry_path`` and reduce it to a ``{date: latest
        row}`` mapping via
-       :meth:`~swxsoc_reach.historical.telemetry.DownloadTelemetry.load_state`.
+       :meth:`~swxsoc_reach.historical.telemetry.HistoricalTelemetry.load_state`.
        Missing/empty file is treated as no prior state.
     3. **Plan.** Expand ``[start_date, end_date]`` into one
        UTC-midnight-bounded window per day, decide an action per day
@@ -291,7 +280,7 @@ def run_download(
         accept the same keyword arguments and return the path to the
         written artifact, or raise ``ValueError`` for an empty window.
         Tests inject a stub here; production callers leave it ``None``.
-    telemetry : DownloadTelemetry, optional
+    telemetry : HistoricalTelemetry, optional
         Override for the telemetry writer/reader. Defaults to one
         backed by ``config.telemetry_path``. Tests may inject a
         pre-populated instance to simulate restart scenarios.
@@ -305,7 +294,7 @@ def run_download(
     if download_fn is None:
         download_fn = udl_module.download_UDL_reach_window
     if telemetry is None:
-        telemetry = DownloadTelemetry(config.telemetry_path)
+        telemetry = HistoricalTelemetry(config.telemetry_path)
 
     run_id = str(uuid.uuid4())
     config.output_dir.mkdir(parents=True, exist_ok=True)
@@ -385,7 +374,7 @@ def run_download(
             expected_records=str(_expected_records(config.sensor_id)),
             started_at_utc=started,
         )
-        telemetry.append_row(TelemetryRow(status=STATUS_PENDING, **base_row))
+        telemetry.append_row(TelemetryRow(status=STATUS_DOWNLOAD_PENDING, **base_row))
 
         t0 = time.monotonic()
         try:

--- a/swxsoc_reach/historical/download_orchestrator.py
+++ b/swxsoc_reach/historical/download_orchestrator.py
@@ -1,0 +1,490 @@
+"""Per-day orchestrator for historical UDL downloads.
+
+Drives :func:`swxsoc_reach.net.udl.download_UDL_reach_window` over an
+inclusive UTC date range, recording one or more rows per day in a
+:class:`~swxsoc_reach.historical.telemetry.DownloadTelemetry` CSV. Days
+that already completed (per telemetry + on-disk artifact) are skipped,
+so reruns are idempotent and resumable.
+
+The orchestrator is intentionally sequential at the day level —
+concurrency lives inside ``download_UDL_reach_window`` via the existing
+thread pool + AIMD rate controller.
+"""
+
+from __future__ import annotations
+
+import time
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+from astropy.time import Time
+
+from swxsoc_reach import log
+from swxsoc_reach.historical.telemetry import (
+    DownloadTelemetry,
+    STATUS_DOWNLOADED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_SKIPPED_NO_DATA,
+    TelemetryRow,
+    utcnow_iso,
+)
+from swxsoc_reach.net import udl as udl_module
+
+# Per-satellite per-dosimeter samples per UTC day at 5-second cadence.
+# Used as the upper-bound reference for ``availability_pct``.
+_SAMPLES_PER_DOSIMETER_PER_DAY = 17_280  # 24 Hours at 5-second cadence
+_REACH_NUM_SATELLITES = 32
+_DOSIMETERS_PER_SATELLITE = 2
+
+EXPECTED_RECORDS_ALL = (
+    _REACH_NUM_SATELLITES * _DOSIMETERS_PER_SATELLITE * _SAMPLES_PER_DOSIMETER_PER_DAY
+)  # 1,105,920
+EXPECTED_RECORDS_SINGLE = (
+    _DOSIMETERS_PER_SATELLITE * _SAMPLES_PER_DOSIMETER_PER_DAY
+)  # 34,560
+
+
+@dataclass
+class DownloadRunConfig:
+    """Inputs to :func:`run_download`.
+
+    Mirrors the historical-download CLI flags one-for-one. The CLI
+    layer in :mod:`swxsoc_reach.__main__` parses argv into one of these
+    instances, then hands it to :func:`run_download`. Tests construct
+    it directly to drive the orchestrator without touching argparse.
+
+    Fields
+    ------
+    - ``start_date`` (``datetime.date``): inclusive UTC start of the
+      date range to process.
+    - ``end_date`` (``datetime.date``): inclusive UTC end of the date
+      range. Must be ``>= start_date``.
+    - ``output_dir`` (``pathlib.Path``): directory where per-day
+      CSV/JSON artifacts are written. Created if missing.
+    - ``telemetry_path`` (``pathlib.Path``): path to the append-only
+      telemetry CSV. Created if missing. Conventionally lives inside
+      ``output_dir``.
+    - ``sensor_id`` (``str``, default ``"ALL"``): REACH sensor
+      identifier or ``"ALL"``. Drives chunk size in
+      :func:`~swxsoc_reach.net.udl.get_reach_datetimelist` (10-min
+      chunks for ``ALL``, 6-hour chunks for a specific sensor) and the
+      expected-records baseline used for ``availability_pct``.
+    - ``descriptor`` (``str``, default ``"QUICKLOOK"``): UDL
+      ``descriptor`` query value.
+    - ``output_format`` (``{'csv', 'json'}``, default ``'csv'``):
+      output serialization format passed through to the downloader.
+    - ``retry_failed`` (``bool``, default ``False``): when ``True``,
+      days whose latest telemetry row is ``FAILED`` are re-attempted;
+      otherwise they are skipped.
+    - ``limit_days`` (``int`` or ``None``): if set, cap the number of
+      days *attempted*, counted from the first day not already
+      ``DOWNLOADED`` with its artifact on disk.
+    - ``dry_run`` (``bool``, default ``False``): when ``True``, no
+      network calls and no telemetry writes — only logs the planned
+      action per day.
+    - ``auth_token`` (``str``): UDL HTTP Basic auth header value.
+      Resolved by the CLI layer from
+      :func:`swxsoc_reach.net.auth.resolve_udl_auth` (Secrets Manager
+      or ``BASICAUTH`` env var).
+    - ``max_concurrent_requests`` (``int``, default ``4``): max
+      concurrent UDL chunk requests per day; forwarded to
+      :func:`~swxsoc_reach.net.udl.download_UDL_reach_window`.
+    - ``initial_rate``, ``additive_increase``,
+      ``multiplicative_decrease``, ``min_rate``, ``max_rate``
+      (``float``): AIMD rate-controller tuning parameters; forwarded
+      to :func:`~swxsoc_reach.net.udl.download_UDL_reach_window`.
+    """
+
+    start_date: date
+    end_date: date
+    output_dir: Path
+    telemetry_path: Path
+    sensor_id: str = "ALL"
+    descriptor: str = "QUICKLOOK"
+    output_format: str = "csv"
+    retry_failed: bool = False
+    limit_days: int | None = None
+    dry_run: bool = False
+    auth_token: str = ""
+    max_concurrent_requests: int = 4
+    initial_rate: float = 5.0
+    additive_increase: float = 1.0
+    multiplicative_decrease: float = 0.5
+    min_rate: float = 5.0
+    max_rate: float = 25.0
+
+
+@dataclass
+class DownloadRunSummary:
+    """Aggregate result of one :func:`run_download` invocation.
+
+    Returned to the CLI layer (or any direct caller) so it can log a
+    final "X downloaded, Y skipped, Z failed" line and choose a
+    process exit code. Per-day detail lives in the telemetry CSV;
+    this struct is intentionally just rollups.
+
+    Fields
+    ------
+    - ``run_id`` (``str``): UUID4 stamped on every telemetry row
+      written by this run. Lets operators correlate rows in the
+      telemetry CSV with a specific invocation.
+    - ``days_planned`` (``int``): days in the inclusive date range
+      considered after applying ``--limit-days``. Equals
+      ``days_attempted + days_skipped_existing + days_skipped_no_data
+      + days_failed`` on a non-dry-run.
+    - ``days_attempted`` (``int``): days for which the downloader was
+      invoked (regardless of outcome).
+    - ``days_downloaded`` (``int``): days that ended in
+      ``DOWNLOADED`` (artifact written, telemetry row appended).
+    - ``days_skipped_existing`` (``int``): days short-circuited
+      because a prior ``DOWNLOADED`` row exists and its CSV artifact
+      is still on disk.
+    - ``days_skipped_no_data`` (``int``): days that ended in
+      ``SKIPPED_NO_DATA`` — either freshly (UDL returned zero
+      records, terminal) or via a prior ``SKIPPED_NO_DATA`` row.
+    - ``days_failed`` (``int``): days that ended in ``FAILED`` (or
+      were skipped because of a prior ``FAILED`` row without
+      ``--retry-failed``).
+    """
+
+    run_id: str
+    days_planned: int
+    days_attempted: int
+    days_downloaded: int
+    days_skipped_existing: int
+    days_skipped_no_data: int
+    days_failed: int
+
+
+def _expected_records(sensor_id: str) -> int:
+    """Upper-bound reference count for ``availability_pct``."""
+    if sensor_id.upper() == "ALL":
+        return EXPECTED_RECORDS_ALL
+    return EXPECTED_RECORDS_SINGLE
+
+
+def _iter_dates(start: date, end: date) -> Iterable[date]:
+    """Yield each UTC date in ``[start, end]`` inclusive."""
+    if end < start:
+        raise ValueError(
+            f"end_date {end.isoformat()} must be >= start_date {start.isoformat()}"
+        )
+    current = start
+    while current <= end:
+        yield current
+        current = current + timedelta(days=1)
+
+
+def _day_window(d: date) -> tuple[Time, Time, str, str]:
+    """Return (start_time, end_time, start_iso, end_iso) for a UTC day.
+
+    ``end_time`` is exclusive: ``start + 86400 s``. Matches the existing
+    chunk-list semantics so records timestamped in the last second of
+    the day are included.
+    """
+    start_dt = datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+    end_dt = start_dt + timedelta(days=1)
+    start_t = Time(
+        start_dt.replace(tzinfo=None).isoformat(), format="isot", scale="utc"
+    )
+    end_t = Time(end_dt.replace(tzinfo=None).isoformat(), format="isot", scale="utc")
+    return start_t, end_t, start_dt.isoformat(), end_dt.isoformat()
+
+
+def _decide_action(
+    chunk_date: date,
+    prior: TelemetryRow | None,
+    retry_failed: bool,
+) -> str:
+    """Return one of ``run`` | ``skip_existing`` | ``skip_terminal`` | ``skip_failed``.
+
+    Decision table (see plan):
+
+    - no prior row → ``run``
+    - prior ``DOWNLOADED`` and CSV exists → ``skip_existing``
+    - prior ``DOWNLOADED`` and CSV missing → ``run`` (re-download)
+    - prior ``SKIPPED_NO_DATA`` → ``skip_terminal``
+    - prior ``FAILED`` → ``skip_failed`` unless ``retry_failed`` then ``run``
+    - prior ``PENDING`` (interrupted) → ``run``
+    """
+    if prior is None:
+        return "run"
+    if prior.status == STATUS_DOWNLOADED:
+        csv_path = prior.csv_path
+        if csv_path and Path(csv_path).exists():
+            return "skip_existing"
+        return "run"
+    if prior.status == STATUS_SKIPPED_NO_DATA:
+        return "skip_terminal"
+    if prior.status == STATUS_FAILED:
+        return "run" if retry_failed else "skip_failed"
+    # PENDING or unknown → re-run.
+    return "run"
+
+
+def run_download(
+    config: DownloadRunConfig,
+    *,
+    download_fn: Callable[..., Path] | None = None,
+    telemetry: DownloadTelemetry | None = None,
+) -> DownloadRunSummary:
+    """Run the historical UDL download orchestrator.
+
+    Steps performed, in order:
+
+    1. **Initialize.** Generate a fresh ``run_id`` (UUID4) used to
+       stamp every telemetry row written by this invocation. Ensure
+       ``config.output_dir`` exists.
+    2. **Load prior state.** Read the telemetry CSV at
+       ``config.telemetry_path`` and reduce it to a ``{date: latest
+       row}`` mapping via
+       :meth:`~swxsoc_reach.historical.telemetry.DownloadTelemetry.load_state`.
+       Missing/empty file is treated as no prior state.
+    3. **Plan.** Expand ``[start_date, end_date]`` into one
+       UTC-midnight-bounded window per day, decide an action per day
+       via :func:`_decide_action` (``run`` / ``skip_existing`` /
+       ``skip_terminal`` / ``skip_failed``), and apply
+       ``--limit-days`` by counting only days whose action is not
+       ``skip_existing``.
+    4. **Execute, sequentially per day.** For each planned day:
+
+       a. If ``config.dry_run``, log the action and continue (no
+          telemetry rows written, no network calls).
+       b. For skip actions, log the reason, increment the matching
+          summary counter, and continue.
+       c. For ``run`` actions, append a ``PENDING`` row, then invoke
+          ``download_fn`` with absolute UTC ``start_time`` /
+          ``end_time`` (00:00:00 → next day 00:00:00, exclusive end)
+          and the AIMD knobs from ``config``.
+
+    5. **Classify outcomes per attempted day.**
+
+       - On success: append a ``DOWNLOADED`` row with
+         ``records_downloaded``, ``availability_pct`` (vs the
+         per-sensor expected-records baseline), ``download_seconds``,
+         ``csv_size_mb``, and ``csv_path``.
+       - On :class:`ValueError` from the downloader (its "no records"
+         signal): append a terminal ``SKIPPED_NO_DATA`` row.
+       - On any other exception: append a ``FAILED`` row with
+         ``error_type`` and ``error_message``. **The orchestrator
+         never aborts mid-range — it continues to the next day.**
+
+    6. **Return** an aggregated :class:`DownloadRunSummary`.
+
+    Concurrency: this function is sequential at the day level.
+    Per-day concurrency lives inside ``download_fn`` (the existing
+    thread pool + AIMD rate controller in
+    :func:`~swxsoc_reach.net.udl.download_UDL_reach_window`).
+
+    Parameters
+    ----------
+    config : DownloadRunConfig
+        Run inputs, typically built from CLI args.
+    download_fn : callable, optional
+        Override for
+        :func:`swxsoc_reach.net.udl.download_UDL_reach_window`. Must
+        accept the same keyword arguments and return the path to the
+        written artifact, or raise ``ValueError`` for an empty window.
+        Tests inject a stub here; production callers leave it ``None``.
+    telemetry : DownloadTelemetry, optional
+        Override for the telemetry writer/reader. Defaults to one
+        backed by ``config.telemetry_path``. Tests may inject a
+        pre-populated instance to simulate restart scenarios.
+
+    Returns
+    -------
+    DownloadRunSummary
+        Aggregate counts for the run. The CLI layer uses these to log
+        the final summary line and choose an exit code.
+    """
+    if download_fn is None:
+        download_fn = udl_module.download_UDL_reach_window
+    if telemetry is None:
+        telemetry = DownloadTelemetry(config.telemetry_path)
+
+    run_id = str(uuid.uuid4())
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    state = telemetry.load_state()
+
+    all_dates = list(_iter_dates(config.start_date, config.end_date))
+
+    # Determine which days need work in order — used for ``--limit-days``
+    # which counts from the first not-yet-complete day.
+    actionable: list[tuple[date, str]] = []
+    for d in all_dates:
+        action = _decide_action(d, state.get(d), config.retry_failed)
+        actionable.append((d, action))
+
+    # Apply --limit-days to the first N days that are not ``skip_existing``.
+    if config.limit_days is not None:
+        kept: list[tuple[date, str]] = []
+        worked = 0
+        for d, action in actionable:
+            if action == "skip_existing":
+                kept.append((d, action))
+                continue
+            if worked >= config.limit_days:
+                break
+            kept.append((d, action))
+            worked += 1
+        actionable = kept
+
+    summary = DownloadRunSummary(
+        run_id=run_id,
+        days_planned=len(actionable),
+        days_attempted=0,
+        days_downloaded=0,
+        days_skipped_existing=0,
+        days_skipped_no_data=0,
+        days_failed=0,
+    )
+
+    for d, action in actionable:
+        start_t, end_t, start_iso, end_iso = _day_window(d)
+        prior = state.get(d)
+
+        if config.dry_run:
+            log.info(
+                f"[dry-run] {d.isoformat()} action={action}"
+                + (f" prior_status={prior.status}" if prior else "")
+            )
+            continue
+
+        if action == "skip_existing":
+            log.info(f"{d.isoformat()}: skip (already DOWNLOADED at {prior.csv_path})")
+            summary.days_skipped_existing += 1
+            continue
+        if action == "skip_terminal":
+            log.info(f"{d.isoformat()}: skip (prior SKIPPED_NO_DATA)")
+            summary.days_skipped_no_data += 1
+            continue
+        if action == "skip_failed":
+            log.info(
+                f"{d.isoformat()}: skip (prior FAILED; pass --retry-failed to retry)"
+            )
+            summary.days_failed += 1
+            continue
+
+        # action == "run"
+        summary.days_attempted += 1
+        started = utcnow_iso()
+        base_row = dict(
+            run_id=run_id,
+            chunk_date_utc=d.isoformat(),
+            window_start_utc=start_iso,
+            window_end_utc=end_iso,
+            sensor_id=config.sensor_id,
+            descriptor=config.descriptor,
+            output_format=config.output_format,
+            expected_records=str(_expected_records(config.sensor_id)),
+            started_at_utc=started,
+        )
+        telemetry.append_row(TelemetryRow(status=STATUS_PENDING, **base_row))
+
+        t0 = time.monotonic()
+        try:
+            csv_path = download_fn(
+                auth_token=config.auth_token,
+                sensor_id=config.sensor_id,
+                descriptor=config.descriptor,
+                output_format=config.output_format,
+                start_time=start_t,
+                end_time=end_t,
+                output_dir=config.output_dir,
+                max_concurrent_requests=config.max_concurrent_requests,
+                initial_rate=config.initial_rate,
+                additive_increase=config.additive_increase,
+                multiplicative_decrease=config.multiplicative_decrease,
+                min_rate=config.min_rate,
+                max_rate=config.max_rate,
+            )
+        except ValueError as exc:
+            # ``download_UDL_reach_window`` raises ValueError for empty
+            # windows. Treat as terminal SKIPPED_NO_DATA.
+            elapsed = time.monotonic() - t0
+            log.info(f"{d.isoformat()}: SKIPPED_NO_DATA ({exc})")
+            telemetry.append_row(
+                TelemetryRow(
+                    status=STATUS_SKIPPED_NO_DATA,
+                    download_seconds=f"{elapsed:.3f}",
+                    error_message=str(exc),
+                    finished_at_utc=utcnow_iso(),
+                    **base_row,
+                )
+            )
+            summary.days_skipped_no_data += 1
+            continue
+        except Exception as exc:  # noqa: BLE001 — orchestrator must not abort
+            elapsed = time.monotonic() - t0
+            log.error(
+                f"{d.isoformat()}: FAILED {type(exc).__name__}: {exc}\n"
+                f"{traceback.format_exc()}"
+            )
+            telemetry.append_row(
+                TelemetryRow(
+                    status=STATUS_FAILED,
+                    download_seconds=f"{elapsed:.3f}",
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    finished_at_utc=utcnow_iso(),
+                    **base_row,
+                )
+            )
+            summary.days_failed += 1
+            continue
+
+        elapsed = time.monotonic() - t0
+        records = _count_records(csv_path, config.output_format)
+        size_mb = csv_path.stat().st_size / (1024 * 1024) if csv_path.exists() else 0.0
+        expected = _expected_records(config.sensor_id)
+        availability = (records / expected * 100.0) if expected else 0.0
+
+        log.info(
+            f"{d.isoformat()}: DOWNLOADED records={records} "
+            f"availability={availability:.1f}% "
+            f"size={size_mb:.2f}MB in {elapsed:.1f}s -> {csv_path}"
+        )
+        telemetry.append_row(
+            TelemetryRow(
+                status=STATUS_DOWNLOADED,
+                records_downloaded=str(records),
+                availability_pct=f"{availability:.4f}",
+                download_seconds=f"{elapsed:.3f}",
+                csv_size_mb=f"{size_mb:.4f}",
+                csv_path=str(csv_path),
+                finished_at_utc=utcnow_iso(),
+                **base_row,
+            )
+        )
+        summary.days_downloaded += 1
+
+    return summary
+
+
+def _count_records(csv_path: Path, output_format: str) -> int:
+    """Count data records in the just-written file.
+
+    Cheap line-count for CSV (header subtracted); for JSON, parse and
+    return ``len(...)``. Errors fall through as 0 — telemetry is not
+    worth crashing the run over.
+    """
+    try:
+        if output_format == "csv":
+            with open(csv_path, "r", encoding="utf-8") as fh:
+                # subtract one for the header row
+                return max(sum(1 for _ in fh) - 1, 0)
+        if output_format == "json":
+            import json
+
+            with open(csv_path, "r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+            return len(payload) if isinstance(payload, list) else 0
+    except OSError:
+        return 0
+    return 0

--- a/swxsoc_reach/historical/process_orchestrator.py
+++ b/swxsoc_reach/historical/process_orchestrator.py
@@ -1,0 +1,551 @@
+"""Per-day orchestrator for historical CSV \u2192 CDF processing.
+
+Drives :func:`swxsoc_reach.calibration.calibration.process_file` over
+an inclusive UTC date range, picking up CSVs produced by Phase 1's
+download orchestrator from ``--input-dir``. Each day produces one
+CDF in ``--output-dir`` and (optionally) one S3 upload via
+:func:`swxsoc_reach.historical.s3_upload.upload_cdf_to_s3`. Telemetry
+is appended to the same CSV file Phase 1 wrote (extended schema), so
+the full download \u2192 process \u2192 upload lifecycle for a given day is
+visible in one place.
+
+Sequential by day, mirroring the download orchestrator. The
+chdir-into-output-dir hack is required because
+``process_file`` writes to ``Path.cwd()`` when ``LAMBDA_ENVIRONMENT``
+is unset (which is the case for historical local runs); we restore
+``cwd`` in ``finally`` so a failure mid-day does not leave the
+process in a bad state.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable
+
+from swxsoc_reach import log
+from swxsoc_reach.historical._dates import iter_dates as _iter_dates
+from swxsoc_reach.historical.telemetry import (
+    HistoricalTelemetry,
+    STATUS_DOWNLOAD_PENDING,
+    STATUS_DOWNLOADED,
+    STATUS_FAILED,
+    STATUS_PROCESS_PENDING,
+    STATUS_PROCESSED,
+    STATUS_SKIPPED_NO_DATA,
+    STATUS_SKIPPED_NO_INPUT,
+    STATUS_UPLOAD_PENDING,
+    STATUS_UPLOADED,
+    TelemetryRow,
+    utcnow_iso,
+)
+
+# Lazy: imported only when needed, to keep ``process_orchestrator``
+# importable on machines without the calibration stack ready.
+
+
+@dataclass
+class ProcessRunConfig:
+    """Inputs to :func:`run_process`.
+
+    Mirrors the historical-process CLI flags one-for-one. The CLI
+    layer parses argv into one of these instances.
+
+    Fields
+    ------
+    - ``start_date``, ``end_date`` : inclusive UTC date range.
+    - ``input_dir`` : directory holding Phase 1 download artifacts
+      (CSV/JSON files named per
+      :func:`~swxsoc_reach.net.udl.build_reach_output_filename`).
+    - ``output_dir`` : directory where CDF files are written.
+    - ``telemetry_path`` : append-only telemetry CSV (typically the
+      same file Phase 1 wrote).
+    - ``sensor_id``, ``descriptor``, ``output_format`` : used to
+      reconstruct the expected per-day input filename when scanning
+      ``input_dir``.
+    - ``retry_failed`` : when True, days with prior status ``FAILED``
+      are re-attempted.
+    - ``limit_days`` : cap on attempted days (counted from the first
+      not-yet-complete day).
+    - ``dry_run`` : plan only - no work, no telemetry writes.
+    - ``upload_to_s3`` : if True, attempt an S3 upload after a
+      successful CDF write. If False, ``PROCESSED`` is the terminal
+      status for the day.
+    - ``s3_bucket`` : destination bucket (required iff
+      ``upload_to_s3`` is True).
+    """
+
+    start_date: date
+    end_date: date
+    input_dir: Path
+    output_dir: Path
+    telemetry_path: Path
+    sensor_id: str = "ALL"
+    descriptor: str = "QUICKLOOK"
+    output_format: str = "csv"
+    retry_failed: bool = False
+    limit_days: int | None = None
+    dry_run: bool = False
+    upload_to_s3: bool = False
+    s3_bucket: str | None = None
+
+
+@dataclass
+class ProcessRunSummary:
+    """Aggregate result of one :func:`run_process` invocation."""
+
+    run_id: str
+    days_planned: int
+    days_attempted: int
+    days_processed: int
+    days_uploaded: int
+    days_skipped_existing: int
+    days_skipped_no_input: int
+    days_failed: int
+
+
+def _match_csv_for_date(
+    input_dir: Path,
+    day: date,
+    sensor_id: str,
+    output_format: str,
+) -> Path | None:
+    """Return the per-day input artifact path or ``None`` if missing.
+
+    Phase 1 names files via
+    :func:`~swxsoc_reach.net.udl.build_reach_output_filename`:
+    ``{sensor_prefix}_{startTIME}_{endTIME}.{output_format}`` where
+    the time format is ``%Y%m%dT%H%M%S``. For a UTC day, the start
+    component is ``YYYYMMDDT000000`` and the end is the next day's
+    ``YYYYMMDDT000000``. We glob loosely on the leading sensor +
+    start-time prefix so any pair of matching start/end timestamps is
+    accepted.
+    """
+    sensor_prefix = "REACH-ALL" if sensor_id.upper() == "ALL" else sensor_id
+    start_str = day.strftime("%Y%m%dT000000")
+    pattern = f"{sensor_prefix}_{start_str}_*.{output_format}"
+    matches = sorted(input_dir.glob(pattern))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        log.warning(
+            f"{day.isoformat()}: multiple input files match {pattern!r} in "
+            f"{input_dir}; using {matches[0].name}"
+        )
+    return matches[0]
+
+
+def _decide_process_action(
+    prior: TelemetryRow | None,
+    *,
+    upload_to_s3: bool,
+    csv_available: bool,
+    retry_failed: bool,
+) -> str:
+    """Return one of:
+
+    - ``run_process``: (re)run process_file from CSV (and upload if configured)
+    - ``run_upload_only``: CDF already exists; just upload
+    - ``skip_existing``: day already terminal; nothing to do
+    - ``skip_terminal``: prior SKIPPED_NO_INPUT and CSV still missing
+    - ``skip_failed``: prior FAILED and ``--retry-failed`` not set
+    """
+    if prior is None:
+        return "run_process" if csv_available else "skip_no_input"
+
+    status = prior.status
+
+    if status == STATUS_UPLOADED:
+        return "skip_existing"
+
+    if status == STATUS_PROCESSED:
+        cdf = prior.cdf_path
+        cdf_exists = bool(cdf) and Path(cdf).exists()
+        if upload_to_s3:
+            if cdf_exists:
+                return "run_upload_only"
+            return "run_process" if csv_available else "skip_no_input"
+        # local-only mode: PROCESSED is terminal
+        if cdf_exists:
+            return "skip_existing"
+        return "run_process" if csv_available else "skip_no_input"
+
+    if status == STATUS_UPLOAD_PENDING:
+        cdf = prior.cdf_path
+        if cdf and Path(cdf).exists():
+            return "run_upload_only"
+        return "run_process" if csv_available else "skip_no_input"
+
+    if status == STATUS_PROCESS_PENDING:
+        return "run_process" if csv_available else "skip_no_input"
+
+    if status == STATUS_FAILED:
+        if not retry_failed:
+            return "skip_failed"
+        return "run_process" if csv_available else "skip_no_input"
+
+    if status == STATUS_SKIPPED_NO_INPUT:
+        return "run_process" if csv_available else "skip_terminal"
+
+    # Phase 1 statuses (DOWNLOAD_PENDING / DOWNLOADED / SKIPPED_NO_DATA):
+    # treat as no prior process-stage row.
+    if status in (STATUS_DOWNLOAD_PENDING, STATUS_DOWNLOADED, STATUS_SKIPPED_NO_DATA):
+        return "run_process" if csv_available else "skip_no_input"
+
+    # Unknown status \u2192 attempt to process if we have an input.
+    return "run_process" if csv_available else "skip_no_input"
+
+
+def _carry_forward(prior: TelemetryRow | None) -> dict[str, str]:
+    """Carry Phase 1 download columns forward onto a Phase 2 row.
+
+    Keeps the most-recent row per day self-describing in the telemetry
+    CSV. When no prior row exists, returns blank values so column
+    positions are populated.
+    """
+    if prior is None:
+        return {
+            "records_downloaded": "",
+            "expected_records": "",
+            "availability_pct": "",
+            "download_seconds": "",
+            "csv_size_mb": "",
+            "csv_path": "",
+        }
+    return {
+        "records_downloaded": prior.records_downloaded,
+        "expected_records": prior.expected_records,
+        "availability_pct": prior.availability_pct,
+        "download_seconds": prior.download_seconds,
+        "csv_size_mb": prior.csv_size_mb,
+        "csv_path": prior.csv_path,
+    }
+
+
+def _process_one_day(
+    csv_path: Path,
+    output_dir: Path,
+    process_fn: Callable[[Path], list[Path]],
+) -> list[Path]:
+    """Run ``process_file(csv_path)`` with cwd switched to ``output_dir``.
+
+    ``process_file`` writes to ``Path.cwd()`` when ``LAMBDA_ENVIRONMENT``
+    is unset, so we chdir for the duration of the call and restore in
+    ``finally``. Sequential per-day execution makes this safe.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved_cwd = os.getcwd()
+    try:
+        os.chdir(output_dir)
+        return list(process_fn(csv_path))
+    finally:
+        os.chdir(saved_cwd)
+
+
+def run_process(
+    config: ProcessRunConfig,
+    *,
+    process_fn: Callable[[Path], list[Path]] | None = None,
+    upload_fn: Callable[..., tuple[str, str]] | None = None,
+    telemetry: HistoricalTelemetry | None = None,
+) -> ProcessRunSummary:
+    """Run the historical CSV -> CDF (-> S3) orchestrator.
+
+    Parameters
+    ----------
+    config : ProcessRunConfig
+        Run inputs, typically built from CLI args.
+    process_fn : callable, optional
+        Override for
+        :func:`swxsoc_reach.calibration.calibration.process_file`.
+        Receives the CSV path and must return a ``list[Path]`` of
+        produced CDFs (written into ``cwd`` per the existing
+        contract). Tests inject a stub here.
+    upload_fn : callable, optional
+        Override for
+        :func:`swxsoc_reach.historical.s3_upload.upload_cdf_to_s3`.
+        Must accept ``(cdf_path, destination_bucket=...)`` keyword
+        args and return ``(bucket, s3_key)``.
+    telemetry : HistoricalTelemetry, optional
+        Override for the telemetry writer/reader.
+
+    Returns
+    -------
+    ProcessRunSummary
+        Aggregate counts. The CLI layer uses these to log the final
+        summary line and choose an exit code.
+    """
+    if process_fn is None:
+        from swxsoc_reach.calibration.calibration import process_file
+
+        process_fn = process_file
+    if upload_fn is None and config.upload_to_s3:
+        from swxsoc_reach.historical.s3_upload import upload_cdf_to_s3
+
+        upload_fn = upload_cdf_to_s3
+    if telemetry is None:
+        telemetry = HistoricalTelemetry(config.telemetry_path)
+
+    if config.upload_to_s3 and not config.s3_bucket:
+        raise ValueError("upload_to_s3=True requires s3_bucket to be set")
+
+    run_id = str(uuid.uuid4())
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    state = telemetry.load_state()
+    all_dates = list(_iter_dates(config.start_date, config.end_date))
+
+    # Plan: per-day action.
+    actionable: list[tuple[date, str, Path | None]] = []
+    for d in all_dates:
+        csv_path = _match_csv_for_date(
+            config.input_dir, d, config.sensor_id, config.output_format
+        )
+        action = _decide_process_action(
+            state.get(d),
+            upload_to_s3=config.upload_to_s3,
+            csv_available=csv_path is not None,
+            retry_failed=config.retry_failed,
+        )
+        actionable.append((d, action, csv_path))
+
+    # --limit-days counts only days that need work (not skip_existing).
+    if config.limit_days is not None:
+        kept: list[tuple[date, str, Path | None]] = []
+        worked = 0
+        for entry in actionable:
+            _, action, _ = entry
+            if action == "skip_existing":
+                kept.append(entry)
+                continue
+            if worked >= config.limit_days:
+                break
+            kept.append(entry)
+            worked += 1
+        actionable = kept
+
+    summary = ProcessRunSummary(
+        run_id=run_id,
+        days_planned=len(actionable),
+        days_attempted=0,
+        days_processed=0,
+        days_uploaded=0,
+        days_skipped_existing=0,
+        days_skipped_no_input=0,
+        days_failed=0,
+    )
+
+    for d, action, csv_path in actionable:
+        prior = state.get(d)
+        date_iso = d.isoformat()
+
+        if config.dry_run:
+            log.info(f"[dry-run] {date_iso} action={action}")
+            continue
+
+        if action == "skip_existing":
+            log.info(f"{date_iso}: skip (already complete)")
+            summary.days_skipped_existing += 1
+            continue
+        if action == "skip_terminal":
+            log.info(f"{date_iso}: skip (prior SKIPPED_NO_INPUT, still no input)")
+            summary.days_skipped_no_input += 1
+            continue
+        if action == "skip_failed":
+            log.info(f"{date_iso}: skip (prior FAILED; pass --retry-failed to retry)")
+            summary.days_failed += 1
+            continue
+        if action == "skip_no_input":
+            log.info(f"{date_iso}: SKIPPED_NO_INPUT (no matching CSV in input-dir)")
+            telemetry.append_row(
+                TelemetryRow(
+                    run_id=run_id,
+                    chunk_date_utc=date_iso,
+                    status=STATUS_SKIPPED_NO_INPUT,
+                    sensor_id=config.sensor_id,
+                    descriptor=config.descriptor,
+                    output_format=config.output_format,
+                    started_at_utc=utcnow_iso(),
+                    finished_at_utc=utcnow_iso(),
+                    **_carry_forward(prior),
+                )
+            )
+            summary.days_skipped_no_input += 1
+            continue
+
+        # action is run_process or run_upload_only
+        carried = _carry_forward(prior)
+        base_row = dict(
+            run_id=run_id,
+            chunk_date_utc=date_iso,
+            sensor_id=config.sensor_id,
+            descriptor=config.descriptor,
+            output_format=config.output_format,
+            **carried,
+        )
+
+        cdf_path: Path | None = None
+        process_seconds = ""
+        cdf_size_mb = ""
+
+        if action == "run_process":
+            assert csv_path is not None  # invariant from _decide_process_action
+            base_row["csv_path"] = str(csv_path)
+            summary.days_attempted += 1
+
+            started = utcnow_iso()
+            telemetry.append_row(
+                TelemetryRow(
+                    status=STATUS_PROCESS_PENDING,
+                    started_at_utc=started,
+                    **base_row,
+                )
+            )
+
+            t0 = time.monotonic()
+            try:
+                produced = _process_one_day(csv_path, config.output_dir, process_fn)
+            except Exception as exc:  # noqa: BLE001 - never abort mid-range
+                elapsed = time.monotonic() - t0
+                log.error(
+                    f"{date_iso}: FAILED at process stage "
+                    f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+                )
+                telemetry.append_row(
+                    TelemetryRow(
+                        status=STATUS_FAILED,
+                        started_at_utc=started,
+                        finished_at_utc=utcnow_iso(),
+                        process_seconds=f"{elapsed:.3f}",
+                        error_type=type(exc).__name__,
+                        error_message=str(exc),
+                        **base_row,
+                    )
+                )
+                summary.days_failed += 1
+                continue
+
+            elapsed = time.monotonic() - t0
+            if not produced:
+                log.error(f"{date_iso}: FAILED process_file returned no paths")
+                telemetry.append_row(
+                    TelemetryRow(
+                        status=STATUS_FAILED,
+                        started_at_utc=started,
+                        finished_at_utc=utcnow_iso(),
+                        process_seconds=f"{elapsed:.3f}",
+                        error_type="RuntimeError",
+                        error_message="process_file returned no output paths",
+                        **base_row,
+                    )
+                )
+                summary.days_failed += 1
+                continue
+            if len(produced) > 1:
+                log.warning(
+                    f"{date_iso}: process_file returned {len(produced)} paths; "
+                    f"recording the first ({produced[0].name})"
+                )
+            cdf_path = Path(produced[0])
+            cdf_size_mb = (
+                f"{cdf_path.stat().st_size / (1024 * 1024):.4f}"
+                if cdf_path.exists()
+                else "0.0000"
+            )
+            process_seconds = f"{elapsed:.3f}"
+
+            base_row["cdf_path"] = str(cdf_path)
+            base_row["cdf_size_mb"] = cdf_size_mb
+            base_row["process_seconds"] = process_seconds
+
+            log.info(
+                f"{date_iso}: PROCESSED size={cdf_size_mb}MB in {process_seconds}s "
+                f"-> {cdf_path}"
+            )
+            telemetry.append_row(
+                TelemetryRow(
+                    status=STATUS_PROCESSED,
+                    started_at_utc=started,
+                    finished_at_utc=utcnow_iso(),
+                    **base_row,
+                )
+            )
+            summary.days_processed += 1
+
+            if not config.upload_to_s3:
+                continue
+            # fall through to upload using cdf_path
+
+        elif action == "run_upload_only":
+            assert prior is not None
+            cdf_path = Path(prior.cdf_path) if prior.cdf_path else None
+            if cdf_path is None or not cdf_path.exists():
+                # Should not reach here given _decide_process_action,
+                # but be defensive.
+                log.warning(
+                    f"{date_iso}: expected existing CDF for upload-only "
+                    f"but path is missing; falling back to skip_failed"
+                )
+                summary.days_failed += 1
+                continue
+            base_row["cdf_path"] = str(cdf_path)
+            base_row["cdf_size_mb"] = prior.cdf_size_mb
+            base_row["process_seconds"] = prior.process_seconds
+
+        # === Upload stage ===
+        if not config.upload_to_s3 or upload_fn is None:
+            continue
+
+        upload_started = utcnow_iso()
+        telemetry.append_row(
+            TelemetryRow(
+                status=STATUS_UPLOAD_PENDING,
+                started_at_utc=upload_started,
+                **base_row,
+            )
+        )
+
+        u0 = time.monotonic()
+        try:
+            bucket, s3_key = upload_fn(cdf_path, destination_bucket=config.s3_bucket)
+        except Exception as exc:  # noqa: BLE001
+            u_elapsed = time.monotonic() - u0
+            log.error(
+                f"{date_iso}: FAILED at upload stage "
+                f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+            )
+            telemetry.append_row(
+                TelemetryRow(
+                    status=STATUS_FAILED,
+                    started_at_utc=upload_started,
+                    finished_at_utc=utcnow_iso(),
+                    upload_seconds=f"{u_elapsed:.3f}",
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    **base_row,
+                )
+            )
+            summary.days_failed += 1
+            continue
+
+        u_elapsed = time.monotonic() - u0
+        log.info(f"{date_iso}: UPLOADED s3://{bucket}/{s3_key} in {u_elapsed:.1f}s")
+        telemetry.append_row(
+            TelemetryRow(
+                status=STATUS_UPLOADED,
+                started_at_utc=upload_started,
+                finished_at_utc=utcnow_iso(),
+                upload_seconds=f"{u_elapsed:.3f}",
+                s3_bucket=bucket,
+                s3_key=s3_key,
+                **base_row,
+            )
+        )
+        summary.days_uploaded += 1
+
+    return summary

--- a/swxsoc_reach/historical/s3_upload.py
+++ b/swxsoc_reach/historical/s3_upload.py
@@ -1,0 +1,104 @@
+"""Local CDF upload helper for the historical process orchestrator.
+
+Mirrors the executor Lambda's ``_upload_reach_file_to_s3`` exactly:
+sets ``SWXSOC_MISSION=swxsoc_pipeline``, calls
+:func:`swxsoc._reconfigure`, and delegates the upload to
+:func:`sdc_aws_utils.aws.push_science_file`.
+
+``push_science_file`` (via :func:`sdc_aws_utils.aws.upload_file_to_s3`)
+hard-codes ``/tmp/{filename}`` as the source path because it was
+written for the Lambda runtime where the CDF already lives in
+``/tmp``. For a local historical run the CDF is in
+``--output-dir`` instead, so this helper stages a copy of the file
+into ``/tmp`` before invoking ``push_science_file`` and removes the
+staged copy afterwards. The original CDF in ``--output-dir`` is left
+untouched.
+
+``boto3`` and ``sdc_aws_utils`` are imported lazily inside the
+function so the package still imports on dev machines that have not
+installed the ``[net]`` extra.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from swxsoc_reach import log
+
+_INSTALL_HINT = (
+    "S3 upload requires the optional 'net' extra: "
+    "pip install 'swxsoc_reach[net]' (provides boto3 + sdc_aws_utils)."
+)
+
+
+def upload_cdf_to_s3(cdf_path: Path, *, destination_bucket: str) -> tuple[str, str]:
+    """Upload a single CDF file to S3 via ``sdc_aws_utils``.
+
+    Parameters
+    ----------
+    cdf_path : pathlib.Path
+        Local path to the CDF file. Must exist on disk.
+    destination_bucket : str
+        Target S3 bucket name (no ``s3://`` prefix).
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(destination_bucket, s3_key)`` where ``s3_key`` is the value
+        returned by :func:`sdc_aws_utils.aws.push_science_file`.
+
+    Raises
+    ------
+    RuntimeError
+        If ``boto3`` or ``sdc_aws_utils`` are not importable. The
+        message includes the install hint.
+    FileNotFoundError
+        If ``cdf_path`` does not exist.
+    """
+    cdf_path = Path(cdf_path)
+    if not cdf_path.is_file():
+        raise FileNotFoundError(f"CDF not found for upload: {cdf_path}")
+
+    try:
+        import boto3  # noqa: F401  -- imported for availability check
+        from sdc_aws_utils.aws import push_science_file
+        from sdc_aws_utils.config import parser as science_filename_parser
+    except ImportError as exc:  # pragma: no cover - exercised via test stub
+        raise RuntimeError(f"{_INSTALL_HINT} (import error: {exc})") from exc
+
+    # ``upload_file_to_s3`` (called inside push_science_file) reads from
+    # ``/tmp/{basename}``. Stage the file there for the duration of the
+    # upload, then remove the staging copy.
+    filename = cdf_path.name
+    tmp_dir = Path(tempfile.gettempdir())
+    staged = tmp_dir / filename
+    if staged.resolve() != cdf_path.resolve():
+        shutil.copy2(cdf_path, staged)
+        staged_was_copied = True
+    else:
+        staged_was_copied = False
+
+    try:
+        s3_key = push_science_file(
+            science_filename_parser=science_filename_parser,
+            destination_bucket=destination_bucket,
+            calibrated_filename=filename,
+        )
+    finally:
+        if staged_was_copied:
+            try:
+                staged.unlink()
+            except OSError as exc:
+                log.warning(f"Failed to remove staged upload {staged}: {exc}")
+
+    log.info(
+        "Uploaded REACH CDF to S3",
+        extra={
+            "cdf_path": str(cdf_path),
+            "destination_bucket": destination_bucket,
+            "s3_key": s3_key,
+        },
+    )
+    return destination_bucket, s3_key

--- a/swxsoc_reach/historical/telemetry.py
+++ b/swxsoc_reach/historical/telemetry.py
@@ -1,7 +1,7 @@
 """Append-only CSV telemetry for the historical UDL download orchestrator.
 
 One row is written per attempt at a per-day download. Older rows for the
-same ``chunk_date_utc`` are *not* removed; :meth:`DownloadTelemetry.load_state`
+same ``chunk_date_utc`` are *not* removed; :meth:`HistoricalTelemetry.load_state`
 returns the most-recent row per date (by ``started_at_utc``), which is
 how restart/resume decisions are made.
 """
@@ -22,6 +22,7 @@ SCHEMA: tuple[str, ...] = (
     "window_start_utc",
     "window_end_utc",
     "status",
+    # Download Columns
     "records_downloaded",
     "expected_records",
     "availability_pct",
@@ -35,16 +36,41 @@ SCHEMA: tuple[str, ...] = (
     "error_message",
     "started_at_utc",
     "finished_at_utc",
+    # Processing Columns
+    "process_seconds",
+    "cdf_size_mb",
+    "cdf_path",
+    # Upload Columns
+    "upload_seconds",
+    "s3_bucket",
+    "s3_key",
 )
 
 # Status values for the download phase.
-STATUS_PENDING = "PENDING"
+STATUS_DOWNLOAD_PENDING = "DOWNLOAD_PENDING"
 STATUS_DOWNLOADED = "DOWNLOADED"
 STATUS_SKIPPED_NO_DATA = "SKIPPED_NO_DATA"
 STATUS_FAILED = "FAILED"
 
+# Status values for the process / upload phase.
+STATUS_PROCESS_PENDING = "PROCESS_PENDING"
+STATUS_PROCESSED = "PROCESSED"
+STATUS_UPLOAD_PENDING = "UPLOAD_PENDING"
+STATUS_UPLOADED = "UPLOADED"
+STATUS_SKIPPED_NO_INPUT = "SKIPPED_NO_INPUT"
+
 VALID_STATUSES: frozenset[str] = frozenset(
-    {STATUS_PENDING, STATUS_DOWNLOADED, STATUS_SKIPPED_NO_DATA, STATUS_FAILED}
+    {
+        STATUS_DOWNLOAD_PENDING,
+        STATUS_DOWNLOADED,
+        STATUS_SKIPPED_NO_DATA,
+        STATUS_FAILED,
+        STATUS_PROCESS_PENDING,
+        STATUS_PROCESSED,
+        STATUS_UPLOAD_PENDING,
+        STATUS_UPLOADED,
+        STATUS_SKIPPED_NO_INPUT,
+    }
 )
 
 
@@ -63,6 +89,7 @@ class TelemetryRow:
     window_start_utc: str = ""
     window_end_utc: str = ""
     status: str = ""
+    # Download Columns
     records_downloaded: str = ""
     expected_records: str = ""
     availability_pct: str = ""
@@ -76,6 +103,14 @@ class TelemetryRow:
     error_message: str = ""
     started_at_utc: str = ""
     finished_at_utc: str = ""
+    # Processing Columns
+    process_seconds: str = ""
+    cdf_size_mb: str = ""
+    cdf_path: str = ""
+    # Upload Columns
+    upload_seconds: str = ""
+    s3_bucket: str = ""
+    s3_key: str = ""
 
     def to_dict(self) -> dict[str, str]:
         """Return the row as a ``{column: str}`` dict in schema order."""
@@ -88,7 +123,7 @@ class TelemetryRow:
         return cls(**{k: v for k, v in raw.items() if k in known})
 
 
-class DownloadTelemetry:
+class HistoricalTelemetry:
     """Append-only CSV writer / reader for download telemetry."""
 
     def __init__(self, telemetry_path: Path | str):

--- a/swxsoc_reach/historical/telemetry.py
+++ b/swxsoc_reach/historical/telemetry.py
@@ -1,0 +1,190 @@
+"""Append-only CSV telemetry for the historical UDL download orchestrator.
+
+One row is written per attempt at a per-day download. Older rows for the
+same ``chunk_date_utc`` are *not* removed; :meth:`DownloadTelemetry.load_state`
+returns the most-recent row per date (by ``started_at_utc``), which is
+how restart/resume decisions are made.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from dataclasses import dataclass, fields
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable
+
+# Schema column order is the file's source-of-truth for the CSV header.
+SCHEMA: tuple[str, ...] = (
+    "run_id",
+    "chunk_date_utc",
+    "window_start_utc",
+    "window_end_utc",
+    "status",
+    "records_downloaded",
+    "expected_records",
+    "availability_pct",
+    "download_seconds",
+    "csv_size_mb",
+    "csv_path",
+    "sensor_id",
+    "descriptor",
+    "output_format",
+    "error_type",
+    "error_message",
+    "started_at_utc",
+    "finished_at_utc",
+)
+
+# Status values for the download phase.
+STATUS_PENDING = "PENDING"
+STATUS_DOWNLOADED = "DOWNLOADED"
+STATUS_SKIPPED_NO_DATA = "SKIPPED_NO_DATA"
+STATUS_FAILED = "FAILED"
+
+VALID_STATUSES: frozenset[str] = frozenset(
+    {STATUS_PENDING, STATUS_DOWNLOADED, STATUS_SKIPPED_NO_DATA, STATUS_FAILED}
+)
+
+
+@dataclass
+class TelemetryRow:
+    """One row in the download telemetry CSV.
+
+    All fields default to ``""`` so callers can populate just the
+    columns relevant for a given status (e.g. a ``PENDING`` row has no
+    ``finished_at_utc`` yet, a ``SKIPPED_NO_DATA`` row has no
+    ``csv_path``, etc.).
+    """
+
+    run_id: str = ""
+    chunk_date_utc: str = ""
+    window_start_utc: str = ""
+    window_end_utc: str = ""
+    status: str = ""
+    records_downloaded: str = ""
+    expected_records: str = ""
+    availability_pct: str = ""
+    download_seconds: str = ""
+    csv_size_mb: str = ""
+    csv_path: str = ""
+    sensor_id: str = ""
+    descriptor: str = ""
+    output_format: str = ""
+    error_type: str = ""
+    error_message: str = ""
+    started_at_utc: str = ""
+    finished_at_utc: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the row as a ``{column: str}`` dict in schema order."""
+        return {f.name: str(getattr(self, f.name)) for f in fields(self)}
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, str]) -> "TelemetryRow":
+        """Build a row from a CSV-parsed dict, ignoring unknown columns."""
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in raw.items() if k in known})
+
+
+class DownloadTelemetry:
+    """Append-only CSV writer / reader for download telemetry."""
+
+    def __init__(self, telemetry_path: Path | str):
+        self.path = Path(telemetry_path)
+
+    def append_row(self, row: TelemetryRow | dict) -> None:
+        """Append a single row, writing the header on first create.
+
+        The file is flushed and ``fsync``-ed before returning so an
+        interrupted run leaves the telemetry on disk in a consistent
+        state.
+        """
+        if isinstance(row, TelemetryRow):
+            data = row.to_dict()
+        else:
+            unknown = set(row) - set(SCHEMA)
+            if unknown:
+                raise ValueError(
+                    f"Unknown telemetry columns: {sorted(unknown)}. Allowed: {SCHEMA}."
+                )
+            data = {col: str(row.get(col, "")) for col in SCHEMA}
+
+        # Reject invalid statuses early — they're the sole field the
+        # orchestrator branches on.
+        status = data.get("status", "")
+        if status and status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid telemetry status {status!r}. "
+                f"Allowed: {sorted(VALID_STATUSES)}."
+            )
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        write_header = not self.path.exists() or self.path.stat().st_size == 0
+
+        # newline="" is required by the csv module on all platforms.
+        with open(self.path, "a", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=SCHEMA)
+            if write_header:
+                writer.writeheader()
+            writer.writerow({col: data.get(col, "") for col in SCHEMA})
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    def load_state(self) -> dict[date, TelemetryRow]:
+        """Return the most-recent row per ``chunk_date_utc``.
+
+        A missing telemetry file returns ``{}``. Rows whose
+        ``chunk_date_utc`` is unparseable are skipped with no error
+        (treated as if they did not exist) so a hand-edited file cannot
+        crash the orchestrator on startup.
+        """
+        if not self.path.exists():
+            return {}
+
+        latest: dict[date, TelemetryRow] = {}
+        latest_started: dict[date, str] = {}
+
+        with open(self.path, "r", newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for raw in reader:
+                row = TelemetryRow.from_dict(raw)
+                try:
+                    chunk_date = date.fromisoformat(row.chunk_date_utc)
+                except ValueError:
+                    continue
+
+                started = row.started_at_utc
+                # "Most recent" by ISO-8601 ``started_at_utc`` lexicographic
+                # compare (we always write UTC). On ties — e.g. PENDING
+                # and DOWNLOADED rows from the same attempt share a
+                # ``started_at_utc`` — file order breaks the tie via
+                # ``>=`` so the later-written row wins.
+                if chunk_date not in latest or started >= latest_started.get(
+                    chunk_date, ""
+                ):
+                    latest[chunk_date] = row
+                    latest_started[chunk_date] = started
+
+        return latest
+
+    def iter_rows(self) -> Iterable[TelemetryRow]:
+        """Yield every row in file order. Useful for tests/debug."""
+        if not self.path.exists():
+            return
+        with open(self.path, "r", newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for raw in reader:
+                yield TelemetryRow.from_dict(raw)
+
+
+def utcnow_iso() -> str:
+    """Return an ISO-8601 UTC timestamp suitable for telemetry columns.
+
+    Format: ``YYYY-MM-DDTHH:MM:SS.ffffff+00:00``. Stable lexicographic
+    ordering, parseable by :func:`datetime.datetime.fromisoformat`.
+    """
+    from datetime import timezone
+
+    return datetime.now(tz=timezone.utc).isoformat()

--- a/swxsoc_reach/net/auth.py
+++ b/swxsoc_reach/net/auth.py
@@ -1,0 +1,103 @@
+"""UDL authentication helpers.
+
+Resolves the UDL HTTP Basic auth credential used by
+:func:`swxsoc_reach.net.udl.download_UDL_reach_window` (and the legacy
+relative-time wrapper). Two sources are supported, in priority order:
+
+1. The ``BASICAUTH`` environment variable (local-dev fallback / what an
+   operator pre-exports).
+2. AWS Secrets Manager via ``SECRET_ARN_UDL`` — the secret's
+   ``SecretString`` is parsed as JSON and the ``basicauth`` field is
+   used. This matches the existing scheduled-Lambda pattern.
+
+``boto3`` is imported lazily inside :func:`resolve_udl_auth` so this
+module remains importable on environments where ``boto3`` is not
+installed (e.g. running the package without the ``net`` extra and
+relying on a pre-set ``BASICAUTH``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from swxsoc_reach import log
+
+_BASICAUTH_ENV = "BASICAUTH"
+_SECRET_ARN_ENV = "SECRET_ARN_UDL"
+_SECRET_KEY = "basicauth"
+
+
+def resolve_udl_auth(region_name: str | None = None) -> str:
+    """Resolve the UDL HTTP Basic auth credential.
+
+    Resolution order:
+
+    1. If ``BASICAUTH`` is set in the environment, return it directly
+       and do not touch AWS.
+    2. Else if ``SECRET_ARN_UDL`` is set, fetch the secret from AWS
+       Secrets Manager, parse its ``SecretString`` as JSON, extract the
+       ``basicauth`` field, write it back to ``os.environ['BASICAUTH']``
+       (so downstream code that reads the env var continues to work
+       unchanged), and return it.
+    3. Else raise :class:`RuntimeError`.
+
+    Parameters
+    ----------
+    region_name : str or None, optional
+        Optional AWS region passed to ``boto3.session.Session``. When
+        ``None``, ``boto3``'s standard region resolution chain is used
+        (``AWS_REGION`` / ``AWS_DEFAULT_REGION`` / config file).
+
+    Returns
+    -------
+    str
+        The UDL HTTP Basic auth credential value.
+
+    Raises
+    ------
+    RuntimeError
+        If neither ``BASICAUTH`` nor ``SECRET_ARN_UDL`` is set, if the
+        ``boto3`` package is not installed when Secrets Manager
+        resolution is attempted, or if the secret payload does not
+        contain a ``basicauth`` key.
+    """
+    pre_set = os.environ.get(_BASICAUTH_ENV)
+    if pre_set:
+        log.info("Using UDL credential from BASICAUTH environment variable")
+        return pre_set
+
+    secret_arn = os.environ.get(_SECRET_ARN_ENV)
+    if not secret_arn:
+        raise RuntimeError(
+            f"UDL credential not found. Set either {_BASICAUTH_ENV} (direct "
+            f"value) or {_SECRET_ARN_ENV} (AWS Secrets Manager ARN containing "
+            f"a JSON object with a '{_SECRET_KEY}' key)."
+        )
+
+    try:
+        import boto3  # lazy import: optional dependency in [net] extra
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{_SECRET_ARN_ENV} is set but boto3 is not installed. Install "
+            "the 'net' extra (pip install 'swxsoc_reach[net]') or set "
+            f"{_BASICAUTH_ENV} directly."
+        ) from exc
+
+    session = boto3.session.Session(region_name=region_name)
+    client = session.client(service_name="secretsmanager")
+    response = client.get_secret_value(SecretId=secret_arn)
+    secret = json.loads(response["SecretString"])
+
+    if _SECRET_KEY not in secret:
+        raise RuntimeError(
+            f"Secret at {_SECRET_ARN_ENV} does not contain required key "
+            f"'{_SECRET_KEY}'."
+        )
+
+    value = secret[_SECRET_KEY]
+    # Mirror existing Lambda pattern: populate BASICAUTH for any
+    # downstream code that reads the env var directly.
+    os.environ[_BASICAUTH_ENV] = value
+    log.info("Resolved UDL credential from AWS Secrets Manager")
+    return value

--- a/swxsoc_reach/net/udl.py
+++ b/swxsoc_reach/net/udl.py
@@ -499,13 +499,13 @@ def _concatenate_chunk_files(
                         out.write(line)
 
 
-def download_UDL_reach_to_file(
+def download_UDL_reach_window(
     auth_token: str,
     sensor_id: str,
     descriptor: str,
     output_format: Literal["json", "csv"],
-    delay_seconds: int,
-    window_seconds: int,
+    start_time: Time,
+    end_time: Time,
     output_dir: Path | str,
     max_concurrent_requests: int = 4,
     initial_rate: float = 5.0,
@@ -514,7 +514,12 @@ def download_UDL_reach_to_file(
     min_rate: float = 5.0,
     max_rate: float = 25.0,
 ) -> Path:
-    """Download REACH data from UDL and write one combined output file.
+    """Download REACH data from UDL for an explicit absolute UTC window.
+
+    Behaves identically to :func:`download_UDL_reach_to_file` except that
+    the query window is provided directly as ``start_time`` / ``end_time``
+    rather than computed relative to ``Time.now()``. Suitable for
+    historical reprocessing where the operator drives the window.
 
     Each chunk is written to a temporary file as it arrives, keeping peak
     memory proportional to one chunk instead of the full dataset.  Temp
@@ -531,11 +536,11 @@ def download_UDL_reach_to_file(
         UDL descriptor value to include in each request.
     output_format : {'json', 'csv'}
         Output serialization format.
-    delay_seconds : int
-        Number of seconds to subtract from ``Time.now()`` before ending the
-        query window.
-    window_seconds : int
-        Duration of the query window in seconds.
+    start_time : astropy.time.Time
+        Inclusive start of the UTC query window.
+    end_time : astropy.time.Time
+        Exclusive end of the UTC query window. Must be strictly after
+        ``start_time``.
     output_dir : pathlib.Path or str
         Directory where the combined output file is written.
     max_concurrent_requests : int, optional
@@ -574,9 +579,6 @@ def download_UDL_reach_to_file(
     # Convert Output directory to Path object
     output_dir = Path(output_dir)
 
-    # Set Start and End times for REACH data query
-    end_time = Time.now() - TimeDelta(delay_seconds, format="sec")
-    start_time = end_time - TimeDelta(window_seconds, format="sec")
     log.info(
         "Starting REACH download-to-file run",
         extra={
@@ -624,7 +626,7 @@ def download_UDL_reach_to_file(
             future_to_chunk = {}
             total_chunks = len(urls)
             for request_index, (dt, url) in enumerate(urls.items(), start=1):
-                log.info(f"Queueing Chunk {request_index} of {total_chunks}")
+                log.debug(f"Queueing Chunk {request_index} of {total_chunks}")
                 chunk_path = tmp_dir_path / f"chunk_{request_index}.tmp"
                 future = executor.submit(
                     _fetch_and_spool_chunk,
@@ -643,7 +645,7 @@ def download_UDL_reach_to_file(
                 total_record_count += record_count
                 if written_path is not None:
                     chunk_files[dt] = written_path
-                log.info(
+                log.debug(
                     f"Received Chunk {request_index} of {total_chunks}. "
                     f"Chunk window: {dt} with {record_count} records."
                 )
@@ -674,3 +676,85 @@ def download_UDL_reach_to_file(
         },
     )
     return filepath
+
+
+def download_UDL_reach_to_file(
+    auth_token: str,
+    sensor_id: str,
+    descriptor: str,
+    output_format: Literal["json", "csv"],
+    delay_seconds: int,
+    window_seconds: int,
+    output_dir: Path | str,
+    max_concurrent_requests: int = 4,
+    initial_rate: float = 5.0,
+    additive_increase: float = 1.0,
+    multiplicative_decrease: float = 0.5,
+    min_rate: float = 5.0,
+    max_rate: float = 25.0,
+) -> Path:
+    """Download REACH data from UDL for a relative-time window.
+
+    Computes ``end_time = Time.now() - delay_seconds`` and
+    ``start_time = end_time - window_seconds`` and delegates to
+    :func:`download_UDL_reach_window`. This is the entry point used by
+    the scheduled Lambda.
+
+    Parameters
+    ----------
+    auth_token : str
+        UDL authorization token value for the ``Authorization`` header.
+    sensor_id : str
+        REACH sensor identifier, or ``ALL``.
+    descriptor : str
+        UDL descriptor value to include in each request.
+    output_format : {'json', 'csv'}
+        Output serialization format.
+    delay_seconds : int
+        Number of seconds to subtract from ``Time.now()`` before ending the
+        query window.
+    window_seconds : int
+        Duration of the query window in seconds.
+    output_dir : pathlib.Path or str
+        Directory where the combined output file is written.
+    max_concurrent_requests : int, optional
+        Maximum number of chunk requests to run concurrently.
+    initial_rate, additive_increase, multiplicative_decrease, min_rate, max_rate : float, optional
+        AIMD rate controller tuning parameters; see
+        :func:`download_UDL_reach_window`.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the written output file.
+
+    Raises
+    ------
+    ValueError
+        If ``output_format`` is invalid or no records are returned.
+    requests.HTTPError
+        If any UDL request fails.
+    """
+    # Validate format eagerly so callers get the same error before any
+    # Time.now() / network work happens (matches prior behavior).
+    if output_format not in {"json", "csv"}:
+        raise ValueError("REACH_FILE_FORMAT must be either 'json' or 'csv'.")
+
+    end_time = Time.now() - TimeDelta(delay_seconds, format="sec")
+    start_time = end_time - TimeDelta(window_seconds, format="sec")
+
+    return download_UDL_reach_window(
+        auth_token=auth_token,
+        sensor_id=sensor_id,
+        descriptor=descriptor,
+        output_format=output_format,
+        start_time=start_time,
+        end_time=end_time,
+        output_dir=output_dir,
+        max_concurrent_requests=max_concurrent_requests,
+        initial_rate=initial_rate,
+        additive_increase=additive_increase,
+        multiplicative_decrease=multiplicative_decrease,
+        min_rate=min_rate,
+        max_rate=max_rate,
+    )

--- a/swxsoc_reach/tests/test_auth.py
+++ b/swxsoc_reach/tests/test_auth.py
@@ -1,0 +1,124 @@
+"""Tests for ``swxsoc_reach.net.auth.resolve_udl_auth``."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from swxsoc_reach.net import auth
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_env(monkeypatch):
+    """Ensure neither auth env var leaks in from the host environment."""
+    monkeypatch.delenv("BASICAUTH", raising=False)
+    monkeypatch.delenv("SECRET_ARN_UDL", raising=False)
+    yield
+
+
+def test_resolve_udl_auth_prefers_basicauth_env(monkeypatch):
+    monkeypatch.setenv("BASICAUTH", "Basic preset-value")
+
+    # If boto3 is touched at all, fail loudly.
+    def boom(*args, **kwargs):
+        raise AssertionError("boto3 must not be imported when BASICAUTH is set")
+
+    monkeypatch.setitem(__import__("sys").modules, "boto3", _ExplodingModule(boom))
+
+    assert auth.resolve_udl_auth() == "Basic preset-value"
+
+
+def test_resolve_udl_auth_raises_when_neither_var_set():
+    with pytest.raises(RuntimeError, match="BASICAUTH"):
+        auth.resolve_udl_auth()
+
+
+def test_resolve_udl_auth_uses_secrets_manager(monkeypatch):
+    monkeypatch.setenv(
+        "SECRET_ARN_UDL", "arn:aws:secretsmanager:us-east-1:123:secret:udl-x"
+    )
+
+    captured = {}
+
+    class FakeClient:
+        def get_secret_value(self, SecretId):
+            captured["SecretId"] = SecretId
+            return {"SecretString": json.dumps({"basicauth": "Basic from-aws"})}
+
+    class FakeSession:
+        def __init__(self, region_name=None):
+            captured["region_name"] = region_name
+
+        def client(self, service_name):
+            captured["service_name"] = service_name
+            return FakeClient()
+
+    fake_boto3 = _Module()
+    fake_boto3.session = _Module()
+    fake_boto3.session.Session = FakeSession
+    monkeypatch.setitem(__import__("sys").modules, "boto3", fake_boto3)
+
+    result = auth.resolve_udl_auth(region_name="us-east-1")
+
+    assert result == "Basic from-aws"
+    # Side effect: BASICAUTH populated for downstream code.
+    assert os.environ["BASICAUTH"] == "Basic from-aws"
+    assert captured["SecretId"] == "arn:aws:secretsmanager:us-east-1:123:secret:udl-x"
+    assert captured["service_name"] == "secretsmanager"
+    assert captured["region_name"] == "us-east-1"
+
+
+def test_resolve_udl_auth_raises_when_secret_missing_basicauth_key(monkeypatch):
+    monkeypatch.setenv(
+        "SECRET_ARN_UDL", "arn:aws:secretsmanager:us-east-1:123:secret:udl-x"
+    )
+
+    class FakeClient:
+        def get_secret_value(self, SecretId):
+            return {"SecretString": json.dumps({"other_key": "x"})}
+
+    class FakeSession:
+        def __init__(self, region_name=None):
+            pass
+
+        def client(self, service_name):
+            return FakeClient()
+
+    fake_boto3 = _Module()
+    fake_boto3.session = _Module()
+    fake_boto3.session.Session = FakeSession
+    monkeypatch.setitem(__import__("sys").modules, "boto3", fake_boto3)
+
+    with pytest.raises(RuntimeError, match="basicauth"):
+        auth.resolve_udl_auth()
+
+
+def test_resolve_udl_auth_raises_when_boto3_missing(monkeypatch):
+    monkeypatch.setenv(
+        "SECRET_ARN_UDL", "arn:aws:secretsmanager:us-east-1:123:secret:udl-x"
+    )
+
+    import sys
+
+    # Simulate boto3 being absent from the environment.
+    monkeypatch.setitem(sys.modules, "boto3", None)
+
+    with pytest.raises(RuntimeError, match="boto3 is not installed"):
+        auth.resolve_udl_auth()
+
+
+# --- helpers ---
+
+
+class _Module:
+    """A lightweight stand-in for a Python module."""
+
+
+class _ExplodingModule:
+    def __init__(self, raiser):
+        self._raiser = raiser
+
+    def __getattr__(self, name):
+        self._raiser()

--- a/swxsoc_reach/tests/test_cli.py
+++ b/swxsoc_reach/tests/test_cli.py
@@ -1,0 +1,217 @@
+"""Tests for the ``python -m swxsoc_reach`` CLI."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from swxsoc_reach import __main__ as cli
+from swxsoc_reach.historical.download_orchestrator import DownloadRunSummary
+
+
+def _argv_download(tmp_path: Path, *extra: str) -> list[str]:
+    return [
+        "download",
+        "--start-date",
+        "2026-01-01",
+        "--end-date",
+        "2026-01-02",
+        "--output-dir",
+        str(tmp_path / "out"),
+        "--sensor-id",
+        "REACH-1",
+        *extra,
+    ]
+
+
+def test_parse_iso_date_valid():
+    assert cli._parse_iso_date("2026-01-15") == date(2026, 1, 15)
+
+
+def test_parse_iso_date_invalid():
+    import argparse
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._parse_iso_date("2026/01/15")
+
+
+def test_build_parser_requires_subcommand():
+    parser = cli._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_download_parser_minimum_args(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(_argv_download(tmp_path))
+    assert args.command == "download"
+    assert args.start_date == date(2026, 1, 1)
+    assert args.end_date == date(2026, 1, 2)
+    assert args.output_dir == tmp_path / "out"
+    assert args.telemetry_file is None
+    assert args.sensor_id == "REACH-1"
+    assert args.descriptor == "QUICKLOOK"
+    assert args.output_format == "csv"
+    assert args.retry_failed is False
+    assert args.dry_run is False
+    assert args.max_concurrent_requests == 4
+
+
+def test_config_from_args_defaults_telemetry_to_output_dir(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(_argv_download(tmp_path))
+    config = cli._config_from_args(args, auth_token="Bearer x")
+    assert config.telemetry_path == tmp_path / "out" / "download_telemetry.csv"
+    assert config.auth_token == "Bearer x"
+
+
+def test_config_from_args_honors_explicit_telemetry_file(tmp_path):
+    custom = tmp_path / "elsewhere" / "t.csv"
+    parser = cli._build_parser()
+    args = parser.parse_args(_argv_download(tmp_path, "--telemetry-file", str(custom)))
+    config = cli._config_from_args(args, auth_token="x")
+    assert config.telemetry_path == custom
+
+
+def test_main_download_dry_run_skips_auth_resolution(tmp_path, monkeypatch):
+    """--dry-run must not call resolve_udl_auth (no network, no creds)."""
+
+    def boom(**kwargs):
+        raise AssertionError("resolve_udl_auth must not run for --dry-run")
+
+    monkeypatch.setattr(cli, "resolve_udl_auth", boom)
+
+    captured = {}
+
+    def fake_run(config):
+        captured["config"] = config
+        return DownloadRunSummary(
+            run_id="r-1",
+            days_planned=2,
+            days_attempted=0,
+            days_downloaded=0,
+            days_skipped_existing=0,
+            days_skipped_no_data=0,
+            days_failed=0,
+        )
+
+    monkeypatch.setattr(cli, "run_download", fake_run)
+
+    rc = cli.main(_argv_download(tmp_path, "--dry-run"))
+    assert rc == 0
+    assert captured["config"].dry_run is True
+    assert captured["config"].auth_token == ""
+
+
+def test_main_download_resolves_auth_and_runs(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        cli, "resolve_udl_auth", lambda region_name=None: "Basic from-aws"
+    )
+
+    captured = {}
+
+    def fake_run(config):
+        captured["config"] = config
+        return DownloadRunSummary(
+            run_id="r-1",
+            days_planned=2,
+            days_attempted=2,
+            days_downloaded=2,
+            days_skipped_existing=0,
+            days_skipped_no_data=0,
+            days_failed=0,
+        )
+
+    monkeypatch.setattr(cli, "run_download", fake_run)
+
+    rc = cli.main(_argv_download(tmp_path))
+    assert rc == 0
+    assert captured["config"].auth_token == "Basic from-aws"
+    assert captured["config"].sensor_id == "REACH-1"
+
+
+def test_main_download_returns_2_when_auth_unavailable(tmp_path, monkeypatch):
+    def fail(**kwargs):
+        raise RuntimeError("BASICAUTH not set")
+
+    monkeypatch.setattr(cli, "resolve_udl_auth", fail)
+    monkeypatch.setattr(
+        cli,
+        "run_download",
+        lambda config: pytest.fail("run_download must not be called"),
+    )
+
+    rc = cli.main(_argv_download(tmp_path))
+    assert rc == 2
+
+
+def test_main_download_returns_1_when_any_day_failed(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "resolve_udl_auth", lambda region_name=None: "x")
+    monkeypatch.setattr(
+        cli,
+        "run_download",
+        lambda config: DownloadRunSummary(
+            run_id="r-1",
+            days_planned=2,
+            days_attempted=2,
+            days_downloaded=1,
+            days_skipped_existing=0,
+            days_skipped_no_data=0,
+            days_failed=1,
+        ),
+    )
+
+    rc = cli.main(_argv_download(tmp_path))
+    assert rc == 1
+
+
+def test_main_download_returns_2_when_dates_inverted(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "run_download",
+        lambda config: pytest.fail("must not run with inverted dates"),
+    )
+
+    rc = cli.main(
+        [
+            "download",
+            "--start-date",
+            "2026-01-05",
+            "--end-date",
+            "2026-01-01",
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--dry-run",
+        ]
+    )
+    assert rc == 2
+
+
+def test_aimd_flags_propagate_to_config(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(
+        _argv_download(
+            tmp_path,
+            "--max-concurrent-requests",
+            "8",
+            "--initial-rate",
+            "10.0",
+            "--additive-increase",
+            "2.0",
+            "--multiplicative-decrease",
+            "0.25",
+            "--min-rate",
+            "2.0",
+            "--max-rate",
+            "50.0",
+        )
+    )
+    config = cli._config_from_args(args, auth_token="x")
+    assert config.max_concurrent_requests == 8
+    assert config.initial_rate == 10.0
+    assert config.additive_increase == 2.0
+    assert config.multiplicative_decrease == 0.25
+    assert config.min_rate == 2.0
+    assert config.max_rate == 50.0

--- a/swxsoc_reach/tests/test_cli.py
+++ b/swxsoc_reach/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_download_parser_minimum_args(tmp_path):
 def test_config_from_args_defaults_telemetry_to_output_dir(tmp_path):
     parser = cli._build_parser()
     args = parser.parse_args(_argv_download(tmp_path))
-    config = cli._config_from_args(args, auth_token="Bearer x")
+    config = cli._download_config_from_args(args, auth_token="Bearer x")
     assert config.telemetry_path == tmp_path / "out" / "download_telemetry.csv"
     assert config.auth_token == "Bearer x"
 
@@ -71,7 +71,7 @@ def test_config_from_args_honors_explicit_telemetry_file(tmp_path):
     custom = tmp_path / "elsewhere" / "t.csv"
     parser = cli._build_parser()
     args = parser.parse_args(_argv_download(tmp_path, "--telemetry-file", str(custom)))
-    config = cli._config_from_args(args, auth_token="x")
+    config = cli._download_config_from_args(args, auth_token="x")
     assert config.telemetry_path == custom
 
 
@@ -208,10 +208,81 @@ def test_aimd_flags_propagate_to_config(tmp_path):
             "50.0",
         )
     )
-    config = cli._config_from_args(args, auth_token="x")
+    config = cli._download_config_from_args(args, auth_token="x")
     assert config.max_concurrent_requests == 8
     assert config.initial_rate == 10.0
     assert config.additive_increase == 2.0
     assert config.multiplicative_decrease == 0.25
     assert config.min_rate == 2.0
     assert config.max_rate == 50.0
+
+
+# --- process subcommand ---
+
+
+def _argv_process(tmp_path: Path, *extra: str) -> list[str]:
+    return [
+        "process",
+        "--start-date",
+        "2026-01-01",
+        "--end-date",
+        "2026-01-02",
+        "--input-dir",
+        str(tmp_path / "in"),
+        "--output-dir",
+        str(tmp_path / "out"),
+        "--sensor-id",
+        "REACH-1",
+        *extra,
+    ]
+
+
+def test_process_parser_minimum_args(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(_argv_process(tmp_path))
+    assert args.command == "process"
+    assert args.input_dir == tmp_path / "in"
+    assert args.output_dir == tmp_path / "out"
+    assert args.upload_to_s3 is False
+    assert args.s3_bucket is None
+    assert args.telemetry_file is None
+
+
+def test_process_config_telemetry_defaults_to_input_dir(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(_argv_process(tmp_path))
+    cfg = cli._process_config_from_args(args)
+    assert cfg.telemetry_path == tmp_path / "in" / "download_telemetry.csv"
+
+
+def test_process_upload_requires_bucket(tmp_path, monkeypatch):
+    """--upload-to-s3 without --s3-bucket exits 2 via parser.error."""
+    monkeypatch.setattr(
+        cli,
+        "run_process",
+        lambda config: pytest.fail("must not run when bucket missing"),
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main(_argv_process(tmp_path, "--upload-to-s3"))
+    assert exc.value.code == 2
+
+
+def test_main_process_returns_1_on_failure(tmp_path, monkeypatch):
+    from swxsoc_reach.historical.process_orchestrator import ProcessRunSummary
+
+    monkeypatch.setattr(
+        cli,
+        "run_process",
+        lambda config: ProcessRunSummary(
+            run_id="r-1",
+            days_planned=2,
+            days_attempted=2,
+            days_processed=1,
+            days_uploaded=0,
+            days_skipped_existing=0,
+            days_skipped_no_input=0,
+            days_failed=1,
+        ),
+    )
+    rc = cli.main(_argv_process(tmp_path, "--dry-run"))
+    assert rc == 1

--- a/swxsoc_reach/tests/test_historical_download.py
+++ b/swxsoc_reach/tests/test_historical_download.py
@@ -16,10 +16,10 @@ from swxsoc_reach.historical.download_orchestrator import (
     run_download,
 )
 from swxsoc_reach.historical.telemetry import (
-    DownloadTelemetry,
+    HistoricalTelemetry,
     STATUS_DOWNLOADED,
     STATUS_FAILED,
-    STATUS_PENDING,
+    STATUS_DOWNLOAD_PENDING,
     STATUS_SKIPPED_NO_DATA,
     TelemetryRow,
 )
@@ -91,7 +91,7 @@ def test_iter_dates_rejects_inverted_range():
     "prior_status,csv_exists,retry_failed,expected",
     [
         (None, False, False, "run"),
-        (STATUS_PENDING, False, False, "run"),
+        (STATUS_DOWNLOAD_PENDING, False, False, "run"),
         (STATUS_DOWNLOADED, True, False, "skip_existing"),
         (STATUS_DOWNLOADED, False, False, "run"),
         (STATUS_SKIPPED_NO_DATA, False, False, "skip_terminal"),
@@ -125,9 +125,9 @@ def test_run_download_single_day_writes_telemetry_and_artifact(tmp_path):
     assert summary.days_downloaded == 1
     assert summary.days_failed == 0
 
-    rows = list(DownloadTelemetry(cfg.telemetry_path).iter_rows())
+    rows = list(HistoricalTelemetry(cfg.telemetry_path).iter_rows())
     statuses = [r.status for r in rows]
-    assert statuses == [STATUS_PENDING, STATUS_DOWNLOADED]
+    assert statuses == [STATUS_DOWNLOAD_PENDING, STATUS_DOWNLOADED]
     final = rows[-1]
     assert final.records_downloaded == "10"
     assert final.expected_records == str(EXPECTED_RECORDS_SINGLE)
@@ -140,7 +140,7 @@ def test_run_download_multi_day_inclusive_range(tmp_path):
     cfg = _config(tmp_path, start_date=date(2026, 1, 1), end_date=date(2026, 1, 3))
     summary = run_download(cfg, download_fn=_make_csv_writer())
     assert summary.days_downloaded == 3
-    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
     assert set(state.keys()) == {
         date(2026, 1, 1),
         date(2026, 1, 2),
@@ -168,7 +168,7 @@ def test_run_download_redownloads_when_csv_missing(tmp_path):
     run_download(cfg, download_fn=_make_csv_writer())
 
     # Delete the CSV.
-    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
     Path(state[date(2026, 1, 1)].csv_path).unlink()
 
     summary = run_download(cfg, download_fn=_make_csv_writer())
@@ -227,7 +227,7 @@ def test_run_download_failure_classification(tmp_path):
     assert summary.days_skipped_no_data == 1
     assert summary.days_failed == 1
 
-    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
     assert state[date(2026, 1, 1)].status == STATUS_SKIPPED_NO_DATA
     assert state[date(2026, 1, 2)].status == STATUS_FAILED
     assert state[date(2026, 1, 2)].error_type == "RuntimeError"
@@ -267,7 +267,7 @@ def test_run_download_limit_days_counts_from_first_incomplete(tmp_path):
     assert summary.days_downloaded == 2
     assert summary.days_skipped_existing == 1
 
-    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
     assert set(state.keys()) == {
         date(2026, 1, 1),
         date(2026, 1, 2),
@@ -278,7 +278,7 @@ def test_run_download_limit_days_counts_from_first_incomplete(tmp_path):
 def test_run_download_uses_expected_records_for_all_sensor(tmp_path):
     cfg = _config(tmp_path, sensor_id="ALL")
     run_download(cfg, download_fn=_make_csv_writer())
-    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
     row = state[date(2026, 1, 1)]
     assert row.expected_records == str(EXPECTED_RECORDS_ALL)
 

--- a/swxsoc_reach/tests/test_historical_download.py
+++ b/swxsoc_reach/tests/test_historical_download.py
@@ -1,0 +1,314 @@
+"""Tests for ``swxsoc_reach.historical.download_orchestrator``."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from swxsoc_reach.historical.download_orchestrator import (
+    DownloadRunConfig,
+    EXPECTED_RECORDS_ALL,
+    EXPECTED_RECORDS_SINGLE,
+    _decide_action,
+    _iter_dates,
+    run_download,
+)
+from swxsoc_reach.historical.telemetry import (
+    DownloadTelemetry,
+    STATUS_DOWNLOADED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_SKIPPED_NO_DATA,
+    TelemetryRow,
+)
+
+
+# --- helpers ---
+
+
+def _config(tmp_path: Path, **overrides) -> DownloadRunConfig:
+    base = dict(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 1),
+        output_dir=tmp_path / "out",
+        telemetry_path=tmp_path / "out" / "download_telemetry.csv",
+        sensor_id="REACH-1",
+        descriptor="QUICKLOOK",
+        output_format="csv",
+        auth_token="Bearer test",
+    )
+    base.update(overrides)
+    return DownloadRunConfig(**base)
+
+
+def _make_csv_writer(records_per_day: int = 5):
+    """Return a download_fn stub that writes a tiny CSV and returns the path."""
+
+    def _fn(**kwargs):
+        sensor_id = kwargs["sensor_id"]
+        start_time = kwargs["start_time"]
+        end_time = kwargs["end_time"]
+        output_dir = Path(kwargs["output_dir"])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        # Filename matches the real downloader's convention closely enough
+        # for tests; we just need a unique path per day.
+        name = f"{sensor_id}_{start_time.isot}_{end_time.isot}.csv".replace(":", "")
+        path = output_dir / name
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("col_a,col_b\n")
+            for i in range(records_per_day):
+                fh.write(f"v{i},w{i}\n")
+        return path
+
+    return _fn
+
+
+# --- date / decision helpers ---
+
+
+def test_iter_dates_inclusive():
+    days = list(_iter_dates(date(2026, 1, 30), date(2026, 2, 2)))
+    assert days == [
+        date(2026, 1, 30),
+        date(2026, 1, 31),
+        date(2026, 2, 1),
+        date(2026, 2, 2),
+    ]
+
+
+def test_iter_dates_single_day():
+    assert list(_iter_dates(date(2026, 1, 1), date(2026, 1, 1))) == [date(2026, 1, 1)]
+
+
+def test_iter_dates_rejects_inverted_range():
+    with pytest.raises(ValueError):
+        list(_iter_dates(date(2026, 1, 2), date(2026, 1, 1)))
+
+
+@pytest.mark.parametrize(
+    "prior_status,csv_exists,retry_failed,expected",
+    [
+        (None, False, False, "run"),
+        (STATUS_PENDING, False, False, "run"),
+        (STATUS_DOWNLOADED, True, False, "skip_existing"),
+        (STATUS_DOWNLOADED, False, False, "run"),
+        (STATUS_SKIPPED_NO_DATA, False, False, "skip_terminal"),
+        (STATUS_FAILED, False, False, "skip_failed"),
+        (STATUS_FAILED, False, True, "run"),
+    ],
+)
+def test_decide_action(tmp_path, prior_status, csv_exists, retry_failed, expected):
+    if prior_status is None:
+        prior = None
+    else:
+        csv_path = ""
+        if csv_exists:
+            p = tmp_path / "x.csv"
+            p.write_text("a\n", encoding="utf-8")
+            csv_path = str(p)
+        prior = TelemetryRow(status=prior_status, csv_path=csv_path)
+
+    assert _decide_action(date(2026, 1, 1), prior, retry_failed) == expected
+
+
+# --- run_download integration ---
+
+
+def test_run_download_single_day_writes_telemetry_and_artifact(tmp_path):
+    cfg = _config(tmp_path)
+    summary = run_download(cfg, download_fn=_make_csv_writer(records_per_day=10))
+
+    assert summary.days_planned == 1
+    assert summary.days_attempted == 1
+    assert summary.days_downloaded == 1
+    assert summary.days_failed == 0
+
+    rows = list(DownloadTelemetry(cfg.telemetry_path).iter_rows())
+    statuses = [r.status for r in rows]
+    assert statuses == [STATUS_PENDING, STATUS_DOWNLOADED]
+    final = rows[-1]
+    assert final.records_downloaded == "10"
+    assert final.expected_records == str(EXPECTED_RECORDS_SINGLE)
+    assert final.csv_path
+    assert Path(final.csv_path).exists()
+    assert final.run_id == summary.run_id
+
+
+def test_run_download_multi_day_inclusive_range(tmp_path):
+    cfg = _config(tmp_path, start_date=date(2026, 1, 1), end_date=date(2026, 1, 3))
+    summary = run_download(cfg, download_fn=_make_csv_writer())
+    assert summary.days_downloaded == 3
+    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    assert set(state.keys()) == {
+        date(2026, 1, 1),
+        date(2026, 1, 2),
+        date(2026, 1, 3),
+    }
+    for row in state.values():
+        assert row.status == STATUS_DOWNLOADED
+
+
+def test_run_download_skips_already_downloaded_days(tmp_path):
+    cfg = _config(tmp_path)
+    run_download(cfg, download_fn=_make_csv_writer())
+
+    # Re-run; downloader stub raises if it gets called.
+    def boom(**kwargs):
+        raise AssertionError("downloader must not be called for already-DOWNLOADED day")
+
+    summary = run_download(cfg, download_fn=boom)
+    assert summary.days_attempted == 0
+    assert summary.days_skipped_existing == 1
+
+
+def test_run_download_redownloads_when_csv_missing(tmp_path):
+    cfg = _config(tmp_path)
+    run_download(cfg, download_fn=_make_csv_writer())
+
+    # Delete the CSV.
+    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    Path(state[date(2026, 1, 1)].csv_path).unlink()
+
+    summary = run_download(cfg, download_fn=_make_csv_writer())
+    assert summary.days_downloaded == 1
+
+
+def test_run_download_skipped_no_data_is_terminal(tmp_path):
+    cfg = _config(tmp_path)
+
+    def empty(**kwargs):
+        raise ValueError("No records returned for sensor")
+
+    summary = run_download(cfg, download_fn=empty)
+    assert summary.days_skipped_no_data == 1
+
+    # Re-run: should not call the downloader.
+    def boom(**kwargs):
+        raise AssertionError("downloader must not be called for SKIPPED_NO_DATA day")
+
+    summary2 = run_download(cfg, download_fn=boom)
+    assert summary2.days_attempted == 0
+    assert summary2.days_skipped_no_data == 1
+
+
+def test_run_download_failed_skipped_unless_retry(tmp_path):
+    cfg = _config(tmp_path)
+
+    def bad(**kwargs):
+        raise RuntimeError("HTTP 500")
+
+    run_download(cfg, download_fn=bad)
+
+    # Default re-run: skip without invoking downloader.
+    def boom(**kwargs):
+        raise AssertionError("downloader must not be called without --retry-failed")
+
+    s1 = run_download(cfg, download_fn=boom)
+    assert s1.days_attempted == 0
+    assert s1.days_failed == 1
+
+    # With retry_failed: should invoke and succeed.
+    cfg_retry = _config(tmp_path, retry_failed=True)
+    s2 = run_download(cfg_retry, download_fn=_make_csv_writer())
+    assert s2.days_downloaded == 1
+
+
+def test_run_download_failure_classification(tmp_path):
+    cfg = _config(tmp_path, start_date=date(2026, 1, 1), end_date=date(2026, 1, 2))
+
+    def per_day(**kwargs):
+        if kwargs["start_time"].isot.startswith("2026-01-01"):
+            raise ValueError("No records returned")
+        raise RuntimeError("connection reset")
+
+    summary = run_download(cfg, download_fn=per_day)
+    assert summary.days_skipped_no_data == 1
+    assert summary.days_failed == 1
+
+    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    assert state[date(2026, 1, 1)].status == STATUS_SKIPPED_NO_DATA
+    assert state[date(2026, 1, 2)].status == STATUS_FAILED
+    assert state[date(2026, 1, 2)].error_type == "RuntimeError"
+    assert state[date(2026, 1, 2)].error_message == "connection reset"
+
+
+def test_run_download_dry_run_writes_no_rows_no_files(tmp_path):
+    cfg = _config(
+        tmp_path,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 3),
+        dry_run=True,
+    )
+
+    def boom(**kwargs):
+        raise AssertionError("downloader must not be called in dry-run")
+
+    summary = run_download(cfg, download_fn=boom)
+    assert summary.days_planned == 3
+    assert summary.days_attempted == 0
+    assert not cfg.telemetry_path.exists()
+
+
+def test_run_download_limit_days_counts_from_first_incomplete(tmp_path):
+    # Day 1 already DOWNLOADED with artifact present.
+    cfg_first = _config(tmp_path)
+    run_download(cfg_first, download_fn=_make_csv_writer())
+
+    cfg = _config(
+        tmp_path,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 5),
+        limit_days=2,
+    )
+    summary = run_download(cfg, download_fn=_make_csv_writer())
+    # Day 1 is skip_existing (does not count); next 2 days run.
+    assert summary.days_downloaded == 2
+    assert summary.days_skipped_existing == 1
+
+    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    assert set(state.keys()) == {
+        date(2026, 1, 1),
+        date(2026, 1, 2),
+        date(2026, 1, 3),
+    }
+
+
+def test_run_download_uses_expected_records_for_all_sensor(tmp_path):
+    cfg = _config(tmp_path, sensor_id="ALL")
+    run_download(cfg, download_fn=_make_csv_writer())
+    state = DownloadTelemetry(cfg.telemetry_path).load_state()
+    row = state[date(2026, 1, 1)]
+    assert row.expected_records == str(EXPECTED_RECORDS_ALL)
+
+
+def test_run_download_passes_aimd_and_window_args_through(tmp_path):
+    cfg = _config(
+        tmp_path,
+        max_concurrent_requests=8,
+        initial_rate=10.0,
+        additive_increase=2.0,
+        multiplicative_decrease=0.25,
+        min_rate=2.0,
+        max_rate=50.0,
+    )
+
+    captured = {}
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return _make_csv_writer()(**kwargs)
+
+    run_download(cfg, download_fn=capture)
+
+    assert captured["max_concurrent_requests"] == 8
+    assert captured["initial_rate"] == 10.0
+    assert captured["additive_increase"] == 2.0
+    assert captured["multiplicative_decrease"] == 0.25
+    assert captured["min_rate"] == 2.0
+    assert captured["max_rate"] == 50.0
+    assert captured["auth_token"] == "Bearer test"
+    # Day boundaries: 00:00:00 → next 00:00:00 (exclusive end)
+    assert captured["start_time"].isot.startswith("2026-01-01T00:00:00")
+    assert captured["end_time"].isot.startswith("2026-01-02T00:00:00")

--- a/swxsoc_reach/tests/test_historical_process.py
+++ b/swxsoc_reach/tests/test_historical_process.py
@@ -1,0 +1,384 @@
+"""Tests for ``swxsoc_reach.historical.process_orchestrator``.
+
+Stubs ``process_fn`` (writes a fake CDF) and ``upload_fn`` (returns a
+fake S3 key) so we never touch real CDF tooling, real boto3, or
+sdc_aws_utils.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from swxsoc_reach.historical.process_orchestrator import (
+    ProcessRunConfig,
+    _decide_process_action,
+    _match_csv_for_date,
+    run_process,
+)
+from swxsoc_reach.historical.telemetry import (
+    HistoricalTelemetry,
+    STATUS_DOWNLOADED,
+    STATUS_FAILED,
+    STATUS_PROCESS_PENDING,
+    STATUS_PROCESSED,
+    STATUS_SKIPPED_NO_INPUT,
+    STATUS_UPLOAD_PENDING,
+    STATUS_UPLOADED,
+    TelemetryRow,
+)
+
+
+# --- helpers ---
+
+
+def _make_csv(input_dir: Path, day: date, sensor_id: str = "REACH-1") -> Path:
+    """Write a fake Phase 1 CSV with the canonical naming pattern."""
+    input_dir.mkdir(parents=True, exist_ok=True)
+    sensor_prefix = "REACH-ALL" if sensor_id.upper() == "ALL" else sensor_id
+    start_str = day.strftime("%Y%m%dT000000")
+    end_day = day.replace(day=day.day) + (date.fromordinal(day.toordinal() + 1) - day)
+    end_str = end_day.strftime("%Y%m%dT000000")
+    name = f"{sensor_prefix}_{start_str}_{end_str}.csv"
+    p = input_dir / name
+    p.write_text("col_a,col_b\nv0,w0\n", encoding="utf-8")
+    return p
+
+
+def _config(tmp_path: Path, **overrides) -> ProcessRunConfig:
+    base = dict(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 1),
+        input_dir=tmp_path / "in",
+        output_dir=tmp_path / "out",
+        telemetry_path=tmp_path / "in" / "download_telemetry.csv",
+        sensor_id="REACH-1",
+        descriptor="QUICKLOOK",
+        output_format="csv",
+    )
+    base.update(overrides)
+    return ProcessRunConfig(**base)
+
+
+def _make_process_fn(records_per_day: int = 1):
+    """Return a process_fn stub that writes a fake CDF in cwd."""
+
+    def _fn(csv_path: Path):
+        # Mirrors process_file's contract: writes to cwd, returns list[Path].
+        cdf_name = csv_path.stem + ".cdf"
+        cdf = Path.cwd() / cdf_name
+        cdf.write_bytes(b"FAKE_CDF" * 32)
+        return [cdf]
+
+    return _fn
+
+
+def _make_upload_fn(key_prefix: str = "l1c/2026/01/"):
+    def _fn(cdf_path, *, destination_bucket):
+        return destination_bucket, f"{key_prefix}{cdf_path.name}"
+
+    return _fn
+
+
+# --- helper coverage ---
+
+
+def test_match_csv_for_date(tmp_path):
+    in_dir = tmp_path / "in"
+    p = _make_csv(in_dir, date(2026, 1, 1), sensor_id="REACH-1")
+    assert _match_csv_for_date(in_dir, date(2026, 1, 1), "REACH-1", "csv") == p
+    assert _match_csv_for_date(in_dir, date(2026, 1, 2), "REACH-1", "csv") is None
+
+
+def test_match_csv_for_date_all_sensor(tmp_path):
+    in_dir = tmp_path / "in"
+    p = _make_csv(in_dir, date(2026, 1, 1), sensor_id="ALL")
+    assert _match_csv_for_date(in_dir, date(2026, 1, 1), "ALL", "csv") == p
+
+
+@pytest.mark.parametrize(
+    "prior_status,upload_to_s3,csv_available,retry_failed,cdf_exists,expected",
+    [
+        # No prior row
+        (None, False, True, False, False, "run_process"),
+        (None, False, False, False, False, "skip_no_input"),
+        # PROCESSED, local-only
+        (STATUS_PROCESSED, False, True, False, True, "skip_existing"),
+        (STATUS_PROCESSED, False, True, False, False, "run_process"),
+        # PROCESSED, upload mode
+        (STATUS_PROCESSED, True, True, False, True, "run_upload_only"),
+        (STATUS_PROCESSED, True, True, False, False, "run_process"),
+        # UPLOADED is always terminal
+        (STATUS_UPLOADED, True, True, False, True, "skip_existing"),
+        (STATUS_UPLOADED, False, True, False, True, "skip_existing"),
+        # UPLOAD_PENDING
+        (STATUS_UPLOAD_PENDING, True, True, False, True, "run_upload_only"),
+        (STATUS_UPLOAD_PENDING, True, True, False, False, "run_process"),
+        # PROCESS_PENDING
+        (STATUS_PROCESS_PENDING, True, True, False, False, "run_process"),
+        (STATUS_PROCESS_PENDING, True, False, False, False, "skip_no_input"),
+        # FAILED
+        (STATUS_FAILED, False, True, False, False, "skip_failed"),
+        (STATUS_FAILED, False, True, True, False, "run_process"),
+        # SKIPPED_NO_INPUT
+        (STATUS_SKIPPED_NO_INPUT, False, False, False, False, "skip_terminal"),
+        (STATUS_SKIPPED_NO_INPUT, False, True, False, False, "run_process"),
+        # Phase 1 statuses are treated as no prior process row
+        (STATUS_DOWNLOADED, False, True, False, False, "run_process"),
+    ],
+)
+def test_decide_process_action(
+    tmp_path,
+    prior_status,
+    upload_to_s3,
+    csv_available,
+    retry_failed,
+    cdf_exists,
+    expected,
+):
+    if prior_status is None:
+        prior = None
+    else:
+        cdf_path = ""
+        if cdf_exists:
+            p = tmp_path / "x.cdf"
+            p.write_bytes(b"x")
+            cdf_path = str(p)
+        prior = TelemetryRow(status=prior_status, cdf_path=cdf_path)
+    assert (
+        _decide_process_action(
+            prior,
+            upload_to_s3=upload_to_s3,
+            csv_available=csv_available,
+            retry_failed=retry_failed,
+        )
+        == expected
+    )
+
+
+# --- run_process integration ---
+
+
+def test_run_process_single_day_local_only(tmp_path):
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    summary = run_process(cfg, process_fn=_make_process_fn())
+
+    assert summary.days_processed == 1
+    assert summary.days_uploaded == 0
+    assert summary.days_failed == 0
+
+    rows = list(HistoricalTelemetry(cfg.telemetry_path).iter_rows())
+    statuses = [r.status for r in rows]
+    assert statuses == [STATUS_PROCESS_PENDING, STATUS_PROCESSED]
+    final = rows[-1]
+    assert final.cdf_path
+    assert Path(final.cdf_path).exists()
+    assert Path(final.cdf_path).parent == cfg.output_dir
+    assert final.cdf_size_mb
+    assert final.run_id == summary.run_id
+
+
+def test_run_process_no_input_records_skipped(tmp_path):
+    cfg = _config(tmp_path)
+    cfg.input_dir.mkdir(parents=True)
+
+    summary = run_process(cfg, process_fn=_make_process_fn())
+    assert summary.days_skipped_no_input == 1
+    assert summary.days_processed == 0
+
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
+    assert state[date(2026, 1, 1)].status == STATUS_SKIPPED_NO_INPUT
+
+
+def test_run_process_skips_already_processed_local_only(tmp_path):
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+    run_process(cfg, process_fn=_make_process_fn())
+
+    def boom(csv_path):
+        raise AssertionError("process_fn must not be called for completed day")
+
+    summary = run_process(cfg, process_fn=boom)
+    assert summary.days_skipped_existing == 1
+    assert summary.days_attempted == 0
+
+
+def test_run_process_reprocesses_when_cdf_missing(tmp_path):
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+    run_process(cfg, process_fn=_make_process_fn())
+
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
+    Path(state[date(2026, 1, 1)].cdf_path).unlink()
+
+    summary = run_process(cfg, process_fn=_make_process_fn())
+    assert summary.days_processed == 1
+
+
+def test_run_process_with_s3_upload(tmp_path):
+    cfg = _config(tmp_path, upload_to_s3=True, s3_bucket="my-bucket")
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    summary = run_process(
+        cfg,
+        process_fn=_make_process_fn(),
+        upload_fn=_make_upload_fn(),
+    )
+
+    assert summary.days_processed == 1
+    assert summary.days_uploaded == 1
+
+    rows = list(HistoricalTelemetry(cfg.telemetry_path).iter_rows())
+    statuses = [r.status for r in rows]
+    assert statuses == [
+        STATUS_PROCESS_PENDING,
+        STATUS_PROCESSED,
+        STATUS_UPLOAD_PENDING,
+        STATUS_UPLOADED,
+    ]
+    final = rows[-1]
+    assert final.s3_bucket == "my-bucket"
+    assert final.s3_key.endswith(".cdf")
+    assert final.upload_seconds
+
+
+def test_run_process_upload_only_resume_from_processed(tmp_path):
+    """Local-only run produces PROCESSED; rerun with --upload-to-s3 should
+    skip processing and only upload."""
+    cfg_local = _config(tmp_path)
+    _make_csv(cfg_local.input_dir, date(2026, 1, 1))
+    run_process(cfg_local, process_fn=_make_process_fn())
+
+    cfg_upload = _config(tmp_path, upload_to_s3=True, s3_bucket="my-bucket")
+
+    def must_not_process(csv_path):
+        raise AssertionError("process_fn must not be called when re-uploading")
+
+    summary = run_process(
+        cfg_upload, process_fn=must_not_process, upload_fn=_make_upload_fn()
+    )
+    assert summary.days_processed == 0
+    assert summary.days_uploaded == 1
+
+
+def test_run_process_uploaded_is_terminal(tmp_path):
+    cfg = _config(tmp_path, upload_to_s3=True, s3_bucket="b")
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+    run_process(cfg, process_fn=_make_process_fn(), upload_fn=_make_upload_fn())
+
+    def boom(*a, **kw):
+        raise AssertionError("must not run again after UPLOADED")
+
+    summary = run_process(cfg, process_fn=boom, upload_fn=boom)
+    assert summary.days_skipped_existing == 1
+
+
+def test_run_process_failure_at_process_stage(tmp_path):
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    def bad(csv_path):
+        raise RuntimeError("boom")
+
+    summary = run_process(cfg, process_fn=bad)
+    assert summary.days_failed == 1
+
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
+    row = state[date(2026, 1, 1)]
+    assert row.status == STATUS_FAILED
+    assert row.error_type == "RuntimeError"
+    assert row.error_message == "boom"
+
+
+def test_run_process_failure_at_upload_stage(tmp_path):
+    cfg = _config(tmp_path, upload_to_s3=True, s3_bucket="b")
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    def bad_upload(cdf_path, *, destination_bucket):
+        raise ConnectionError("net down")
+
+    summary = run_process(cfg, process_fn=_make_process_fn(), upload_fn=bad_upload)
+    assert summary.days_processed == 1
+    assert summary.days_failed == 1
+
+    rows = list(HistoricalTelemetry(cfg.telemetry_path).iter_rows())
+    statuses = [r.status for r in rows]
+    assert statuses[-2:] == [STATUS_UPLOAD_PENDING, STATUS_FAILED]
+    assert rows[-1].error_type == "ConnectionError"
+
+
+def test_run_process_failed_skip_unless_retry(tmp_path):
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+    run_process(
+        cfg, process_fn=lambda csv_path: (_ for _ in ()).throw(RuntimeError("x"))
+    )
+
+    def boom(csv_path):
+        raise AssertionError("must not run without --retry-failed")
+
+    s1 = run_process(cfg, process_fn=boom)
+    assert s1.days_failed == 1
+    assert s1.days_attempted == 0
+
+    cfg_retry = _config(tmp_path, retry_failed=True)
+    s2 = run_process(cfg_retry, process_fn=_make_process_fn())
+    assert s2.days_processed == 1
+
+
+def test_run_process_dry_run_no_writes(tmp_path):
+    cfg = _config(
+        tmp_path,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 3),
+        dry_run=True,
+    )
+    cfg.input_dir.mkdir(parents=True)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    def boom(csv_path):
+        raise AssertionError("must not run in dry-run")
+
+    summary = run_process(cfg, process_fn=boom)
+    assert summary.days_planned == 3
+    assert summary.days_attempted == 0
+    assert not cfg.telemetry_path.exists()
+
+
+def test_run_process_limit_days_after_resume(tmp_path):
+    # Day 1 already PROCESSED, in local-only mode (terminal).
+    cfg_first = _config(tmp_path)
+    _make_csv(cfg_first.input_dir, date(2026, 1, 1))
+    run_process(cfg_first, process_fn=_make_process_fn())
+
+    # Make CSVs for days 2, 3, 4, 5
+    for d in (date(2026, 1, 2), date(2026, 1, 3), date(2026, 1, 4), date(2026, 1, 5)):
+        _make_csv(cfg_first.input_dir, d)
+
+    cfg = _config(
+        tmp_path,
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 5),
+        limit_days=2,
+    )
+    summary = run_process(cfg, process_fn=_make_process_fn())
+    assert summary.days_skipped_existing == 1
+    assert summary.days_processed == 2
+
+
+def test_run_process_upload_to_s3_requires_bucket():
+    cfg = ProcessRunConfig(
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 1),
+        input_dir=Path("/tmp/in"),
+        output_dir=Path("/tmp/out"),
+        telemetry_path=Path("/tmp/t.csv"),
+        upload_to_s3=True,
+        s3_bucket=None,
+    )
+    with pytest.raises(ValueError, match="s3_bucket"):
+        run_process(cfg, process_fn=_make_process_fn())

--- a/swxsoc_reach/tests/test_historical_telemetry.py
+++ b/swxsoc_reach/tests/test_historical_telemetry.py
@@ -9,11 +9,11 @@ import pytest
 
 from swxsoc_reach.historical import telemetry as tm
 from swxsoc_reach.historical.telemetry import (
-    DownloadTelemetry,
+    HistoricalTelemetry,
     SCHEMA,
     STATUS_DOWNLOADED,
     STATUS_FAILED,
-    STATUS_PENDING,
+    STATUS_DOWNLOAD_PENDING,
     STATUS_SKIPPED_NO_DATA,
     TelemetryRow,
 )
@@ -25,7 +25,7 @@ def _row(**overrides) -> TelemetryRow:
         chunk_date_utc="2026-01-01",
         window_start_utc="2026-01-01T00:00:00+00:00",
         window_end_utc="2026-01-02T00:00:00+00:00",
-        status=STATUS_PENDING,
+        status=STATUS_DOWNLOAD_PENDING,
         sensor_id="REACH-1",
         descriptor="QUICKLOOK",
         output_format="csv",
@@ -37,9 +37,9 @@ def _row(**overrides) -> TelemetryRow:
 
 def test_append_row_writes_header_then_appends(tmp_path):
     path = tmp_path / "download_telemetry.csv"
-    t = DownloadTelemetry(path)
+    t = HistoricalTelemetry(path)
 
-    t.append_row(_row(status=STATUS_PENDING))
+    t.append_row(_row(status=STATUS_DOWNLOAD_PENDING))
     t.append_row(
         _row(
             status=STATUS_DOWNLOADED,
@@ -56,42 +56,42 @@ def test_append_row_writes_header_then_appends(tmp_path):
     # Header + 2 data rows
     assert rows[0] == list(SCHEMA)
     assert len(rows) == 3
-    assert rows[1][SCHEMA.index("status")] == STATUS_PENDING
+    assert rows[1][SCHEMA.index("status")] == STATUS_DOWNLOAD_PENDING
     assert rows[2][SCHEMA.index("status")] == STATUS_DOWNLOADED
     assert rows[2][SCHEMA.index("records_downloaded")] == "1234"
 
 
 def test_append_row_creates_parent_directories(tmp_path):
     path = tmp_path / "nested" / "deep" / "telemetry.csv"
-    t = DownloadTelemetry(path)
+    t = HistoricalTelemetry(path)
     t.append_row(_row())
     assert path.exists()
 
 
 def test_append_row_rejects_unknown_columns(tmp_path):
-    t = DownloadTelemetry(tmp_path / "t.csv")
+    t = HistoricalTelemetry(tmp_path / "t.csv")
     with pytest.raises(ValueError, match="Unknown telemetry columns"):
         t.append_row({"chunk_date_utc": "2026-01-01", "bogus": "x"})
 
 
 def test_append_row_rejects_invalid_status(tmp_path):
-    t = DownloadTelemetry(tmp_path / "t.csv")
+    t = HistoricalTelemetry(tmp_path / "t.csv")
     with pytest.raises(ValueError, match="Invalid telemetry status"):
         t.append_row(_row(status="WHATEVER"))
 
 
 def test_load_state_empty_when_no_file(tmp_path):
-    t = DownloadTelemetry(tmp_path / "missing.csv")
+    t = HistoricalTelemetry(tmp_path / "missing.csv")
     assert t.load_state() == {}
 
 
 def test_load_state_returns_most_recent_row_per_date(tmp_path):
-    t = DownloadTelemetry(tmp_path / "t.csv")
+    t = HistoricalTelemetry(tmp_path / "t.csv")
 
     # Two attempts on 2026-01-01: PENDING then FAILED (retry).
     t.append_row(
         _row(
-            status=STATUS_PENDING,
+            status=STATUS_DOWNLOAD_PENDING,
             started_at_utc="2026-01-01T00:00:00.000000+00:00",
         )
     )
@@ -125,7 +125,7 @@ def test_load_state_returns_most_recent_row_per_date(tmp_path):
 
 def test_load_state_skips_rows_with_unparseable_chunk_date(tmp_path):
     path = tmp_path / "t.csv"
-    t = DownloadTelemetry(path)
+    t = HistoricalTelemetry(path)
     t.append_row(_row(chunk_date_utc="2026-01-01"))
 
     # Hand-write a junk row to simulate corruption.
@@ -142,7 +142,7 @@ def test_load_state_skips_rows_with_unparseable_chunk_date(tmp_path):
 
 
 def test_iter_rows_returns_all_rows_in_order(tmp_path):
-    t = DownloadTelemetry(tmp_path / "t.csv")
+    t = HistoricalTelemetry(tmp_path / "t.csv")
     t.append_row(_row(chunk_date_utc="2026-01-01"))
     t.append_row(_row(chunk_date_utc="2026-01-02"))
 
@@ -151,7 +151,7 @@ def test_iter_rows_returns_all_rows_in_order(tmp_path):
 
 
 def test_iter_rows_when_file_missing_yields_nothing(tmp_path):
-    t = DownloadTelemetry(tmp_path / "missing.csv")
+    t = HistoricalTelemetry(tmp_path / "missing.csv")
     assert list(t.iter_rows()) == []
 
 

--- a/swxsoc_reach/tests/test_historical_telemetry.py
+++ b/swxsoc_reach/tests/test_historical_telemetry.py
@@ -1,0 +1,170 @@
+"""Tests for ``swxsoc_reach.historical.telemetry``."""
+
+from __future__ import annotations
+
+import csv
+from datetime import date
+
+import pytest
+
+from swxsoc_reach.historical import telemetry as tm
+from swxsoc_reach.historical.telemetry import (
+    DownloadTelemetry,
+    SCHEMA,
+    STATUS_DOWNLOADED,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_SKIPPED_NO_DATA,
+    TelemetryRow,
+)
+
+
+def _row(**overrides) -> TelemetryRow:
+    base = dict(
+        run_id="run-1",
+        chunk_date_utc="2026-01-01",
+        window_start_utc="2026-01-01T00:00:00+00:00",
+        window_end_utc="2026-01-02T00:00:00+00:00",
+        status=STATUS_PENDING,
+        sensor_id="REACH-1",
+        descriptor="QUICKLOOK",
+        output_format="csv",
+        started_at_utc="2026-01-01T00:00:00.000000+00:00",
+    )
+    base.update(overrides)
+    return TelemetryRow(**base)
+
+
+def test_append_row_writes_header_then_appends(tmp_path):
+    path = tmp_path / "download_telemetry.csv"
+    t = DownloadTelemetry(path)
+
+    t.append_row(_row(status=STATUS_PENDING))
+    t.append_row(
+        _row(
+            status=STATUS_DOWNLOADED,
+            records_downloaded="1234",
+            csv_path="/out/foo.csv",
+            finished_at_utc="2026-01-01T00:01:00.000000+00:00",
+        )
+    )
+
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        rows = list(reader)
+
+    # Header + 2 data rows
+    assert rows[0] == list(SCHEMA)
+    assert len(rows) == 3
+    assert rows[1][SCHEMA.index("status")] == STATUS_PENDING
+    assert rows[2][SCHEMA.index("status")] == STATUS_DOWNLOADED
+    assert rows[2][SCHEMA.index("records_downloaded")] == "1234"
+
+
+def test_append_row_creates_parent_directories(tmp_path):
+    path = tmp_path / "nested" / "deep" / "telemetry.csv"
+    t = DownloadTelemetry(path)
+    t.append_row(_row())
+    assert path.exists()
+
+
+def test_append_row_rejects_unknown_columns(tmp_path):
+    t = DownloadTelemetry(tmp_path / "t.csv")
+    with pytest.raises(ValueError, match="Unknown telemetry columns"):
+        t.append_row({"chunk_date_utc": "2026-01-01", "bogus": "x"})
+
+
+def test_append_row_rejects_invalid_status(tmp_path):
+    t = DownloadTelemetry(tmp_path / "t.csv")
+    with pytest.raises(ValueError, match="Invalid telemetry status"):
+        t.append_row(_row(status="WHATEVER"))
+
+
+def test_load_state_empty_when_no_file(tmp_path):
+    t = DownloadTelemetry(tmp_path / "missing.csv")
+    assert t.load_state() == {}
+
+
+def test_load_state_returns_most_recent_row_per_date(tmp_path):
+    t = DownloadTelemetry(tmp_path / "t.csv")
+
+    # Two attempts on 2026-01-01: PENDING then FAILED (retry).
+    t.append_row(
+        _row(
+            status=STATUS_PENDING,
+            started_at_utc="2026-01-01T00:00:00.000000+00:00",
+        )
+    )
+    t.append_row(
+        _row(
+            status=STATUS_FAILED,
+            error_type="HTTPError",
+            error_message="boom",
+            started_at_utc="2026-01-01T00:05:00.000000+00:00",
+            finished_at_utc="2026-01-01T00:05:30.000000+00:00",
+        )
+    )
+    # One attempt on 2026-01-02: SKIPPED_NO_DATA.
+    t.append_row(
+        _row(
+            chunk_date_utc="2026-01-02",
+            window_start_utc="2026-01-02T00:00:00+00:00",
+            window_end_utc="2026-01-03T00:00:00+00:00",
+            status=STATUS_SKIPPED_NO_DATA,
+            started_at_utc="2026-01-02T00:00:00.000000+00:00",
+        )
+    )
+
+    state = t.load_state()
+
+    assert set(state.keys()) == {date(2026, 1, 1), date(2026, 1, 2)}
+    assert state[date(2026, 1, 1)].status == STATUS_FAILED
+    assert state[date(2026, 1, 1)].error_message == "boom"
+    assert state[date(2026, 1, 2)].status == STATUS_SKIPPED_NO_DATA
+
+
+def test_load_state_skips_rows_with_unparseable_chunk_date(tmp_path):
+    path = tmp_path / "t.csv"
+    t = DownloadTelemetry(path)
+    t.append_row(_row(chunk_date_utc="2026-01-01"))
+
+    # Hand-write a junk row to simulate corruption.
+    with open(path, "a", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=SCHEMA)
+        bad = {col: "" for col in SCHEMA}
+        bad["chunk_date_utc"] = "not-a-date"
+        bad["status"] = STATUS_DOWNLOADED
+        bad["started_at_utc"] = "9999-01-01T00:00:00+00:00"
+        writer.writerow(bad)
+
+    state = t.load_state()
+    assert set(state.keys()) == {date(2026, 1, 1)}
+
+
+def test_iter_rows_returns_all_rows_in_order(tmp_path):
+    t = DownloadTelemetry(tmp_path / "t.csv")
+    t.append_row(_row(chunk_date_utc="2026-01-01"))
+    t.append_row(_row(chunk_date_utc="2026-01-02"))
+
+    rows = list(t.iter_rows())
+    assert [r.chunk_date_utc for r in rows] == ["2026-01-01", "2026-01-02"]
+
+
+def test_iter_rows_when_file_missing_yields_nothing(tmp_path):
+    t = DownloadTelemetry(tmp_path / "missing.csv")
+    assert list(t.iter_rows()) == []
+
+
+def test_telemetry_row_to_dict_uses_schema_columns():
+    row = _row()
+    d = row.to_dict()
+    assert set(d.keys()) == set(SCHEMA)
+
+
+def test_utcnow_iso_returns_parseable_utc_timestamp():
+    from datetime import datetime
+
+    s = tm.utcnow_iso()
+    parsed = datetime.fromisoformat(s)
+    assert parsed.utcoffset() is not None
+    assert parsed.utcoffset().total_seconds() == 0

--- a/swxsoc_reach/tests/test_udl.py
+++ b/swxsoc_reach/tests/test_udl.py
@@ -353,6 +353,182 @@ def test_download_udl_reach_to_file_rejects_invalid_output_format(monkeypatch):
             )
 
 
+# --- download_UDL_reach_window (absolute-time) tests ---
+
+
+def test_download_udl_reach_window_csv_with_absolute_times(monkeypatch):
+    """Absolute-time entry point should write the same artifacts without
+    consulting Time.now()."""
+
+    def boom_now():
+        raise AssertionError("Time.now() must not be called for absolute-time API")
+
+    monkeypatch.setattr(udl.Time, "now", staticmethod(boom_now))
+
+    monkeypatch.setattr(
+        udl,
+        "get_reach_datetimelist",
+        lambda start_time, end_time, sensor_id: ["window-1"],
+    )
+    monkeypatch.setattr(
+        udl,
+        "get_reach_urllist",
+        lambda dtlist, sensor_id, descriptor: {
+            "window-1": "https://example.test/chunk1"
+        },
+    )
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [
+                {
+                    "idSensor": "REACH-1",
+                    "obTime": "2026-01-01T00:00:00.000Z",
+                    "flux": 7.5,
+                }
+            ]
+
+    monkeypatch.setattr(
+        udl.requests, "get", lambda url, headers, timeout: FakeResponse()
+    )
+
+    start_time = Time("2026-01-01T00:00:00", format="isot", scale="utc")
+    end_time = Time("2026-01-02T00:00:00", format="isot", scale="utc")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = udl.download_UDL_reach_window(
+            auth_token="Bearer test-token",
+            sensor_id="REACH-1",
+            descriptor="proton",
+            output_format="csv",
+            start_time=start_time,
+            end_time=end_time,
+            output_dir=Path(tmpdir),
+        )
+
+        assert output_path.parent == Path(tmpdir)
+        assert output_path.exists()
+        assert output_path.name == "REACH-1_20260101T000000_20260102T000000.csv"
+
+        with open(output_path, "r", encoding="utf-8", newline="") as infile:
+            rows = list(csv.DictReader(infile))
+
+        assert rows == [
+            {
+                "idSensor": "REACH-1",
+                "obTime": "2026-01-01T00:00:00.000Z",
+                "flux": "7.5",
+            }
+        ]
+
+
+def test_download_udl_reach_window_raises_on_no_records(monkeypatch):
+    monkeypatch.setattr(
+        udl,
+        "get_reach_datetimelist",
+        lambda start_time, end_time, sensor_id: ["window-1"],
+    )
+    monkeypatch.setattr(
+        udl,
+        "get_reach_urllist",
+        lambda dtlist, sensor_id, descriptor: {
+            "window-1": "https://example.test/chunk1"
+        },
+    )
+
+    class EmptyResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return []
+
+    monkeypatch.setattr(
+        udl.requests, "get", lambda url, headers, timeout: EmptyResponse()
+    )
+
+    start_time = Time("2026-01-01T00:00:00", format="isot", scale="utc")
+    end_time = Time("2026-01-02T00:00:00", format="isot", scale="utc")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="No records returned"):
+            udl.download_UDL_reach_window(
+                auth_token="Bearer test-token",
+                sensor_id="REACH-1",
+                descriptor="proton",
+                output_format="csv",
+                start_time=start_time,
+                end_time=end_time,
+                output_dir=Path(tmpdir),
+            )
+
+
+def test_download_udl_reach_window_rejects_invalid_output_format(monkeypatch):
+    monkeypatch.setattr(
+        udl.requests,
+        "get",
+        lambda *args, **kwargs: pytest.fail("requests.get should not be called"),
+    )
+
+    start_time = Time("2026-01-01T00:00:00", format="isot", scale="utc")
+    end_time = Time("2026-01-02T00:00:00", format="isot", scale="utc")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="REACH_FILE_FORMAT"):
+            udl.download_UDL_reach_window(
+                auth_token="Bearer test-token",
+                sensor_id="REACH-1",
+                descriptor="electron",
+                output_format="txt",
+                start_time=start_time,
+                end_time=end_time,
+                output_dir=tmpdir,
+            )
+
+
+def test_download_udl_reach_to_file_delegates_to_window(monkeypatch):
+    """Legacy relative-time API should compute its window from Time.now()
+    and delegate to download_UDL_reach_window."""
+    fixed_now = Time("2026-01-01T01:00:00", format="isot", scale="utc")
+    monkeypatch.setattr(udl.Time, "now", staticmethod(lambda: fixed_now))
+
+    captured = {}
+    sentinel = Path("/tmp/sentinel.csv")
+
+    def fake_window(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(udl, "download_UDL_reach_window", fake_window)
+
+    result = udl.download_UDL_reach_to_file(
+        auth_token="Bearer t",
+        sensor_id="REACH-1",
+        descriptor="electron",
+        output_format="csv",
+        delay_seconds=60,
+        window_seconds=600,
+        output_dir="/tmp/out",
+    )
+
+    assert result is sentinel
+    expected_end = fixed_now - udl.TimeDelta(60, format="sec")
+    expected_start = expected_end - udl.TimeDelta(600, format="sec")
+    assert captured["start_time"].isot == expected_start.isot
+    assert captured["end_time"].isot == expected_end.isot
+    assert captured["sensor_id"] == "REACH-1"
+    assert captured["descriptor"] == "electron"
+    assert captured["output_format"] == "csv"
+    assert captured["output_dir"] == "/tmp/out"
+
+
 # --- AdaptiveRateController tests ---
 
 


### PR DESCRIPTION
- New `python -m swxsoc_reach` argparse entry point with two subcommands:
  - `download` — backfill REACH UDL data over absolute UTC date ranges.
  - `process` — convert per-day CSVs into CDFs and (optionally) upload to S3 via `sdc_aws_utils`.
- Both subcommands share idempotent restart, `--retry-failed`, `--limit-days`, `--dry-run`, and exit codes `0` / `1` / `2`.
- New shared primitive `swxsoc_reach.net.udl.download_UDL_reach_window`; the existing `download_UDL_reach_to_file` is refactored to delegate to it (no behavior change for the scheduled Lambda).
- New `swxsoc_reach.historical` package: append-only telemetry CSV (`HistoricalTelemetry`, extended schema covering download → process → upload, `fsync`-per-row), shared date-range helper, and two per-day orchestrators (`run_download` / `run_process`) that classify each day with stage-prefixed statuses (`DOWNLOAD_PENDING`, `DOWNLOADED`, `SKIPPED_NO_DATA`, `PROCESS_PENDING`, `PROCESSED`, `SKIPPED_NO_INPUT`, `UPLOAD_PENDING`, `UPLOADED`, `FAILED`) and never abort mid-run.
- New `swxsoc_reach.historical.s3_upload.upload_cdf_to_s3` wraps `sdc_aws_utils.aws.push_science_file` (stages the CDF in `/tmp` to satisfy the helper's hardcoded path) and returns `(bucket, s3_key)`.
- New `swxsoc_reach.net.auth.resolve_udl_auth` resolves UDL Basic-auth from `BASICAUTH` or AWS Secrets Manager (`SECRET_ARN_UDL`); `boto3` and `sdc_aws_utils` are lazy-imported and ship under a new optional `[net]` extra.
- Docs: new user-guide pages `Historical UDL Download CLI` and `Historical CSV → CDF Processing CLI`, plus API autosummary entries for the new modules.

resolves #22 
