### PR TITLE
Output Processed CDF Files to Nested Path if Possible

### DIFF
--- a/swxsoc_reach/historical/process_orchestrator.py
+++ b/swxsoc_reach/historical/process_orchestrator.py
@@ -20,6 +20,7 @@ process in a bad state.
 from __future__ import annotations
 
 import os
+import shutil
 import time
 import traceback
 import uuid
@@ -247,6 +248,43 @@ def _process_one_day(
         os.chdir(saved_cwd)
 
 
+def _relocate_to_nested_layout(flat_path: Path, output_dir: Path) -> Path:
+    """Move *flat_path* into a nested subdirectory of *output_dir*.
+
+    The subdirectory mirrors the S3 key produced by
+    :func:`sdc_aws_utils.aws.create_s3_file_key` (e.g.
+    ``l1c/prelim/2026/01/01/``). Falls back to returning *flat_path*
+    unchanged if ``sdc_aws_utils`` or ``swxsoc`` are not importable, or
+    if key computation raises for any reason.
+    """
+    try:
+        from sdc_aws_utils.aws import create_s3_file_key
+        from swxsoc.util.util import parse_science_filename
+    except ImportError:
+        log.debug(
+            f"_relocate_to_nested_layout: sdc_aws_utils/swxsoc not available; "
+            f"keeping flat layout for {flat_path.name!r}"
+        )
+        return flat_path
+
+    try:
+        nested_key = create_s3_file_key(parse_science_filename, flat_path.name)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            f"Could not compute nested layout key for {flat_path.name!r}; "
+            f"keeping flat ({type(exc).__name__}: {exc})"
+        )
+        return flat_path
+
+    dest = output_dir / nested_key
+    if dest.resolve() == flat_path.resolve():
+        return flat_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(flat_path), dest)
+    log.debug(f"Relocated CDF to nested layout: {dest}")
+    return dest
+
+
 def run_process(
     config: ProcessRunConfig,
     *,
@@ -451,7 +489,7 @@ def run_process(
                     f"{date_iso}: process_file returned {len(produced)} paths; "
                     f"recording the first ({produced[0].name})"
                 )
-            cdf_path = Path(produced[0])
+            cdf_path = _relocate_to_nested_layout(Path(produced[0]), config.output_dir)
             cdf_size_mb = (
                 f"{cdf_path.stat().st_size / (1024 * 1024):.4f}"
                 if cdf_path.exists()

--- a/swxsoc_reach/tests/test_historical_process.py
+++ b/swxsoc_reach/tests/test_historical_process.py
@@ -7,6 +7,8 @@ sdc_aws_utils.
 
 from __future__ import annotations
 
+import sys
+import types
 from datetime import date
 from pathlib import Path
 
@@ -16,6 +18,7 @@ from swxsoc_reach.historical.process_orchestrator import (
     ProcessRunConfig,
     _decide_process_action,
     _match_csv_for_date,
+    _relocate_to_nested_layout,
     run_process,
 )
 from swxsoc_reach.historical.telemetry import (
@@ -382,3 +385,243 @@ def test_run_process_upload_to_s3_requires_bucket():
     )
     with pytest.raises(ValueError, match="s3_bucket"):
         run_process(cfg, process_fn=_make_process_fn())
+
+
+# ---------------------------------------------------------------------------
+# _relocate_to_nested_layout unit tests
+# ---------------------------------------------------------------------------
+
+# CDF filename that parse_science_filename can handle (matches real REACH output).
+_REACH_CDF = "reach_all_l1c_prelim_20260101T000000_v1.0.0.cdf"
+_NESTED_KEY = "l1c/prelim/2026/01/01/" + _REACH_CDF
+
+
+def _fake_sdc_modules(nested_key: str) -> tuple[types.ModuleType, types.ModuleType]:
+    """Return fake (sdc_aws_utils, sdc_aws_utils.aws) module objects."""
+    fake_aws = types.ModuleType("sdc_aws_utils.aws")
+    fake_aws.create_s3_file_key = lambda parser, filename: nested_key
+    fake_sdc = types.ModuleType("sdc_aws_utils")
+    fake_sdc.aws = fake_aws
+    return fake_sdc, fake_aws
+
+
+def _fake_swxsoc_modules() -> tuple[
+    types.ModuleType, types.ModuleType, types.ModuleType
+]:
+    """Return fake (swxsoc, swxsoc.util, swxsoc.util.util) module objects."""
+    sentinel_parser = object()
+    fake_util_util = types.ModuleType("swxsoc.util.util")
+    fake_util_util.parse_science_filename = sentinel_parser
+    fake_util = types.ModuleType("swxsoc.util")
+    fake_util.util = fake_util_util
+    fake_swxsoc = types.ModuleType("swxsoc")
+    fake_swxsoc.util = fake_util
+    return fake_swxsoc, fake_util, fake_util_util
+
+
+def test_relocate_to_nested_layout_success(tmp_path, monkeypatch):
+    """When sdc_aws_utils is importable and key computation succeeds, the CDF
+    is moved into the nested subdirectory under output_dir."""
+    flat = tmp_path / _REACH_CDF
+    flat.write_bytes(b"FAKE_CDF" * 32)
+    output_dir = tmp_path  # same root; nested dest will be a subdirectory
+
+    fake_sdc, fake_aws = _fake_sdc_modules(_NESTED_KEY)
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils", fake_sdc)
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils.aws", fake_aws)
+    monkeypatch.setitem(sys.modules, "swxsoc", fake_swxsoc)
+    monkeypatch.setitem(sys.modules, "swxsoc.util", fake_util)
+    monkeypatch.setitem(sys.modules, "swxsoc.util.util", fake_util_util)
+
+    result = _relocate_to_nested_layout(flat, output_dir)
+
+    expected = output_dir / _NESTED_KEY
+    assert result == expected
+    assert expected.exists()
+    assert not flat.exists()  # moved, not copied
+
+
+def test_relocate_to_nested_layout_import_error(tmp_path, monkeypatch):
+    """When sdc_aws_utils is not importable, the flat path is returned unchanged."""
+    flat = tmp_path / _REACH_CDF
+    flat.write_bytes(b"FAKE_CDF" * 32)
+
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils", None)
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils.aws", None)
+
+    result = _relocate_to_nested_layout(flat, tmp_path)
+
+    assert result == flat
+    assert flat.exists()
+
+
+def test_relocate_to_nested_layout_key_computation_error(tmp_path, monkeypatch):
+    """When create_s3_file_key raises, the flat path is returned unchanged."""
+    flat = tmp_path / _REACH_CDF
+    flat.write_bytes(b"FAKE_CDF" * 32)
+
+    def _boom(parser, filename):
+        raise ValueError("bad filename")
+
+    fake_aws = types.ModuleType("sdc_aws_utils.aws")
+    fake_aws.create_s3_file_key = _boom
+    fake_sdc = types.ModuleType("sdc_aws_utils")
+    fake_sdc.aws = fake_aws
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils", fake_sdc)
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils.aws", fake_aws)
+    monkeypatch.setitem(sys.modules, "swxsoc", fake_swxsoc)
+    monkeypatch.setitem(sys.modules, "swxsoc.util", fake_util)
+    monkeypatch.setitem(sys.modules, "swxsoc.util.util", fake_util_util)
+
+    result = _relocate_to_nested_layout(flat, tmp_path)
+
+    assert result == flat
+    assert flat.exists()
+
+
+def test_relocate_to_nested_layout_already_at_dest(tmp_path, monkeypatch):
+    """When the computed dest equals the flat path, no move occurs."""
+    # Create a file already sitting at the nested path.
+    nested_dir = tmp_path / "l1c" / "prelim" / "2026" / "01" / "01"
+    nested_dir.mkdir(parents=True)
+    already_nested = nested_dir / _REACH_CDF
+    already_nested.write_bytes(b"FAKE_CDF" * 32)
+
+    # Tell the fake key builder to return the *same* relative path.
+    full_nested_key = "l1c/prelim/2026/01/01/" + _REACH_CDF
+    fake_aws = types.ModuleType("sdc_aws_utils.aws")
+    fake_aws.create_s3_file_key = lambda parser, filename: full_nested_key
+    fake_sdc = types.ModuleType("sdc_aws_utils")
+    fake_sdc.aws = fake_aws
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils", fake_sdc)
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils.aws", fake_aws)
+    monkeypatch.setitem(sys.modules, "swxsoc", fake_swxsoc)
+    monkeypatch.setitem(sys.modules, "swxsoc.util", fake_util)
+    monkeypatch.setitem(sys.modules, "swxsoc.util.util", fake_util_util)
+
+    result = _relocate_to_nested_layout(already_nested, tmp_path)
+
+    assert result == already_nested
+    assert already_nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# run_process integration: nested layout
+# ---------------------------------------------------------------------------
+
+
+def _make_process_fn_reach(cdf_name: str = _REACH_CDF):
+    """Like _make_process_fn but writes a properly-named REACH CDF."""
+
+    def _fn(csv_path: Path):
+        cdf = Path.cwd() / cdf_name
+        cdf.write_bytes(b"FAKE_CDF" * 32)
+        return [cdf]
+
+    return _fn
+
+
+def test_run_process_nested_layout_integration(tmp_path, monkeypatch):
+    """When sdc_aws_utils is importable, process_fn output is relocated
+    to the nested path and telemetry records the nested cdf_path."""
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    fake_sdc, fake_aws = _fake_sdc_modules(_NESTED_KEY)
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils", fake_sdc)
+    monkeypatch.setitem(sys.modules, "sdc_aws_utils.aws", fake_aws)
+    monkeypatch.setitem(sys.modules, "swxsoc", fake_swxsoc)
+    monkeypatch.setitem(sys.modules, "swxsoc.util", fake_util)
+    monkeypatch.setitem(sys.modules, "swxsoc.util.util", fake_util_util)
+
+    summary = run_process(cfg, process_fn=_make_process_fn_reach())
+    assert summary.days_processed == 1
+    assert summary.days_failed == 0
+
+    from swxsoc_reach.historical.telemetry import HistoricalTelemetry
+
+    state = HistoricalTelemetry(cfg.telemetry_path).load_state()
+    row = state[date(2026, 1, 1)]
+    assert row.status == "PROCESSED"
+
+    expected_path = cfg.output_dir / _NESTED_KEY
+    assert row.cdf_path == str(expected_path)
+    assert expected_path.exists()
+    # flat location should no longer exist
+    assert not (cfg.output_dir / _REACH_CDF).exists()
+
+
+def test_run_process_nested_layout_skip_existing_on_rerun(tmp_path, monkeypatch):
+    """After a nested-layout run, rerunning skips the day (already complete)."""
+    cfg = _config(tmp_path)
+    _make_csv(cfg.input_dir, date(2026, 1, 1))
+
+    fake_sdc, fake_aws = _fake_sdc_modules(_NESTED_KEY)
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    for key, val in [
+        ("sdc_aws_utils", fake_sdc),
+        ("sdc_aws_utils.aws", fake_aws),
+        ("swxsoc", fake_swxsoc),
+        ("swxsoc.util", fake_util),
+        ("swxsoc.util.util", fake_util_util),
+    ]:
+        monkeypatch.setitem(sys.modules, key, val)
+
+    run_process(cfg, process_fn=_make_process_fn_reach())
+
+    def boom(csv_path):
+        raise AssertionError("must not reprocess a completed nested-layout day")
+
+    summary = run_process(cfg, process_fn=boom)
+    assert summary.days_skipped_existing == 1
+    assert summary.days_attempted == 0
+
+
+def test_run_process_nested_layout_upload_only(tmp_path, monkeypatch):
+    """Nested-layout CDF path flows into upload_fn correctly."""
+    cfg_local = _config(tmp_path)
+    _make_csv(cfg_local.input_dir, date(2026, 1, 1))
+
+    fake_sdc, fake_aws = _fake_sdc_modules(_NESTED_KEY)
+    fake_swxsoc, fake_util, fake_util_util = _fake_swxsoc_modules()
+
+    for key, val in [
+        ("sdc_aws_utils", fake_sdc),
+        ("sdc_aws_utils.aws", fake_aws),
+        ("swxsoc", fake_swxsoc),
+        ("swxsoc.util", fake_util),
+        ("swxsoc.util.util", fake_util_util),
+    ]:
+        monkeypatch.setitem(sys.modules, key, val)
+
+    run_process(cfg_local, process_fn=_make_process_fn_reach())
+
+    cfg_upload = _config(tmp_path, upload_to_s3=True, s3_bucket="my-bucket")
+
+    received_paths: list[Path] = []
+
+    def capturing_upload_fn(cdf_path, *, destination_bucket):
+        received_paths.append(cdf_path)
+        return destination_bucket, f"l1c/prelim/2026/01/01/{cdf_path.name}"
+
+    def must_not_process(csv_path):
+        raise AssertionError("process_fn must not run for upload-only resume")
+
+    summary = run_process(
+        cfg_upload,
+        process_fn=must_not_process,
+        upload_fn=capturing_upload_fn,
+    )
+
+    assert summary.days_uploaded == 1
+    assert len(received_paths) == 1
+    assert received_paths[0] == cfg_upload.output_dir / _NESTED_KEY

--- a/swxsoc_reach/tests/test_transform.py
+++ b/swxsoc_reach/tests/test_transform.py
@@ -1,4 +1,3 @@
-
 import pandas as pd
 import pytest
 


### PR DESCRIPTION
- Adds local nested CDF output layout in the historical process orchestrator to mirror S3 key structure (for example `l1c/prelim/YYYY/MM/DD/...`) instead of only flat output directories.  
- Uses lazy imports for key generation (`create_s3_file_key` + `parse_science_filename`) and preserves backward compatibility by falling back to flat layout if imports or key computation fail.  
- Integrates relocation immediately after `process_file` output so telemetry `cdf_path`, resume/reprocessing checks, and upload-only flows all use the final resolved path.  
- Includes comprehensive new tests for success, fallback scenarios, no-op behavior, nested end-to-end processing, rerun skip semantics, and upload-only with nested paths.