### PR TITLE
Conditional Around Template

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,4 +1,8 @@
+{%- if builder == 'epub' %}
+{%- extends "!layout.html" %}
+{%- else %}
 {%- extends "pydata_sphinx_theme/layout.html" %}
+{%- endif %}
 
 {%- block extrahead %}
 {{ super() }}


### PR DESCRIPTION
### Fix: Sphinx EPUB build fails with `TemplateNotFound: pydata_sphinx_theme/layout.html`

#### Problem

The Sphinx HTML and PDF builds succeed, but the EPUB build fails with:

```
sphinx.errors.ThemeError: An error happened in rendering the page _autosummary/swxsoc_reach.
Reason: TemplateNotFound("'pydata_sphinx_theme/layout.html' not found in
[_StrPath('.../docs/_templates'),
 _StrPath('.../sphinx/themes/epub'),
 _StrPath('.../sphinx/themes/basic')]")
```

#### Root cause

Our project-level template override at layout.html unconditionally extended the pydata theme layout:

```jinja
{%- extends "pydata_sphinx_theme/layout.html" %}
```

The EPUB builder doesn't use `pydata_sphinx_theme` — it uses Sphinx's built-in `epub` / `basic` themes. Since `pydata_sphinx_theme/layout.html` isn't on the EPUB theme search path, Jinja2 raised `TemplateNotFound` and Sphinx aborted with a `ThemeError`. HTML and PDF (LaTeX) were unaffected because they use different builders / themes that don't go through this template.

#### Fix

Make the `extends` directive builder-aware in layout.html:

```jinja
{%- if builder == 'epub' %}
{%- extends "!layout.html" %}
{%- else %}
{%- extends "pydata_sphinx_theme/layout.html" %}
{%- endif %}
```

- For the `epub` builder, fall back to the theme's own layout.html. The `!` prefix tells Sphinx to bypass the project-level template override and resolve layout.html from the active theme's search path (the `epub` / `basic` themes), avoiding infinite self-extension.
- For all other builders (HTML, PDF via LaTeX, etc.) behavior is unchanged — we still extend `pydata_sphinx_theme/layout.html` and inject the favicon links via the `extrahead` block.

The favicon `extrahead` block is left in place; it's harmless for EPUB (resolves to relative paths in the xhtml output).

#### Verification

```bash
cd docs
rm -rf _build/epub _build/doctrees
python -m sphinx -T -b epub -d _build/doctrees -D language=en . _build/epub
```

Result: `build succeeded, 3 warnings.` and `swxsoc_reach.epub` is produced in `_build/epub/`.

HTML and PDF builds were also re-run and continue to succeed with no visible changes.

#### Remaining (pre-existing) warnings

The EPUB build still emits two unrelated `unknown mimetype for favicon.ico, ignoring [epub.unknown_project_files]` warnings and one `conf value "version" should not be empty for EPUB3` warning. These are pre-existing and out of scope for this fix; happy to address them in a follow-up if desired (e.g., guard the favicon block on `builder != 'epub'` and set a `version` in `conf.py`).