### PR TITLE
Make Sure Geomap Flavor Dimension includes All Flavors

### DIFF
--- a/swxsoc_reach/calibration/calibration.py
+++ b/swxsoc_reach/calibration/calibration.py
@@ -108,15 +108,21 @@ def process_file(
                         log.info(f"Saved geomap plot to {plot_png_path}")
                         output_files.append(plot_png_path)
 
-                except ValueError as e:
+                except ValueError:
                     log.warning(
-                        f"Could not create geomap for flavor {flavor.name}: {e}"
+                        "Could not create geomap for flavor %s",
+                        flavor.name,
+                        exc_info=True,
                     )
-                except Exception as e:
-                    log.warning(f"Error creating geomap for flavor {flavor.name}: {e}")
+                except Exception:
+                    log.warning(
+                        "Error creating geomap for flavor %s",
+                        flavor.name,
+                        exc_info=True,
+                    )
 
         except Exception as e:
-            log.warning(f"Could not create geomaps and plots: {e}")
+            log.warning(f"Could not create geomaps and plots: {e}", exc_info=True)
 
         return output_files
     # Otherwise, assume it's a raw CSV/JSON file that needs to be processed into a CDF.

--- a/swxsoc_reach/geomap/geomapbase.py
+++ b/swxsoc_reach/geomap/geomapbase.py
@@ -99,7 +99,7 @@ class GenericGeoMap(SWXData):
             )
 
         # Parse out the Statistic Map for each flavor
-        # shape: (1, nflavors, lat, lon)
+        # shape: (nflavors, lat, lon)
         all_flavor_data = self[f"{statistic}_map"].data[0]
 
         # Make sure the number of flavors in the metadata matches the number of slices in the statistic map

--- a/swxsoc_reach/geomap/geomapbase.py
+++ b/swxsoc_reach/geomap/geomapbase.py
@@ -97,7 +97,18 @@ class GenericGeoMap(SWXData):
             raise ValueError(
                 f"Statistic '{statistic}' is not available in this GenericGeoMap."
             )
+
+        # Parse out the Statistic Map for each flavor
+        # shape: (1, nflavors, lat, lon)
         all_flavor_data = self[f"{statistic}_map"].data[0]
+
+        # Make sure the number of flavors in the metadata matches the number of slices in the statistic map
+        if all_flavor_data.shape[0] != len(self.flavor_names):
+            raise ValueError(
+                "GeoMap flavor metadata does not match the data axis. "
+                f"Metadata has {len(self.flavor_names)} flavors but "
+                f"'{statistic}_map' stores {all_flavor_data.shape[0]} slices."
+            )
         if flavor.name not in self.flavor_names:
             raise ValueError(
                 f"Flavor '{flavor.name}' is not available in this GenericGeoMap."

--- a/swxsoc_reach/tests/test_calibration.py
+++ b/swxsoc_reach/tests/test_calibration.py
@@ -86,6 +86,8 @@ def test_process_file_target(tmpdir, monkeypatch):
     # Make sure the level 2 CDF can be loaded by a GenericGeoMap object
     geomap = GenericGeoMap.load(level_2_files[0])
     assert isinstance(geomap, GenericGeoMap)
+    assert list(geomap.flavor_names) == ["U", "V", "W", "X", "Y", "Z"]
+    assert geomap["median_map"].data.shape[1] == 6
 
 
 def test_process_file_cdf_creates_geomaps(tmpdir, monkeypatch):

--- a/swxsoc_reach/tests/test_geomapbase.py
+++ b/swxsoc_reach/tests/test_geomapbase.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.nddata import NDData
 from cartopy import crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.collections import QuadMesh
@@ -62,6 +63,12 @@ def test_shape_property(test_geomap):
 def test_flavor_names_property(test_geomap):
     """flavor_names should list the six dosimeter flavors in canonical order."""
     assert list(test_geomap.flavor_names) == ["U", "V", "W", "X", "Y", "Z"]
+
+
+def test_statistic_maps_preserve_six_flavor_axis(test_geomap):
+    """All statistic maps should retain the canonical six-flavor axis."""
+    for statistic in ("sum", "mean", "median", "count", "min", "max", "std"):
+        assert test_geomap[f"{statistic}_map"].data.shape[1] == 6
 
 
 def test_lon_property(test_geomap):
@@ -143,6 +150,20 @@ def test_map_data(test_geomap):
     # The per-flavor maps only contain U, V, W, X, Y, Z, so Flavor.ALL is absent.
     with pytest.raises(ValueError):
         test_geomap.map_data("median", Flavor.ALL)
+
+
+def test_map_data_raises_for_misaligned_flavor_metadata(test_geomap):
+    """map_data should fail loudly when flavor metadata and data axes disagree."""
+    original = test_geomap["dosimeter_flavor_names"]
+    test_geomap.support["dosimeter_flavor_names"] = NDData(
+        data=original.data[:-1],
+        meta=original.meta,
+    )
+
+    with pytest.raises(
+        ValueError, match="flavor metadata does not match the data axis"
+    ):
+        test_geomap.map_data("median", Flavor.X)
 
 
 def test_plot_returns_geoaxes_and_mesh(test_geomap):

--- a/swxsoc_reach/tests/test_trackbase.py
+++ b/swxsoc_reach/tests/test_trackbase.py
@@ -1,12 +1,14 @@
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 from astropy.timeseries import TimeSeries
 from cartopy.mpl.geoaxes import GeoAxes
 
 from swxsoc_reach import _test_file_track
+from swxsoc_reach.geomap import GenericGeoMap
 from swxsoc_reach.track.trackbase import REACHTrack
-from swxsoc_reach.util.enums import SensorId
+from swxsoc_reach.util.enums import Flavor, SensorId
 
 
 @pytest.fixture
@@ -143,3 +145,32 @@ def test_timeseries_has_region_code_column(reach_track_swx):
     ts = reach_track_swx.get_track(reach_id=SensorId.from_str(0))
     assert "region_code" in ts.colnames
     assert len(ts["region_code"]) == len(ts.time)
+
+
+@pytest.fixture
+def sparse_flavor_reach_track(reach_track_swx) -> REACHTrack:
+    reach_track_swx["dosimeter_flavors"].data[:] = [
+        "DOSE1 (Flavor V) in rad/second",
+        "DOSE2 (Flavor Y) in rad/second",
+    ]
+    return reach_track_swx
+
+
+def test_to_geomap_preserves_canonical_flavor_axis(sparse_flavor_reach_track):
+    geomap = sparse_flavor_reach_track.to_geomap()
+
+    assert isinstance(geomap, GenericGeoMap)
+    assert list(geomap.flavor_names) == ["U", "V", "W", "X", "Y", "Z"]
+    for statistic in ("sum", "mean", "median", "count", "min", "max", "std"):
+        assert geomap[f"{statistic}_map"].data.shape[1] == 6
+
+
+def test_to_geomap_fills_missing_flavors(sparse_flavor_reach_track):
+    geomap = sparse_flavor_reach_track.to_geomap()
+
+    for flavor in (Flavor.U, Flavor.W, Flavor.X, Flavor.Z):
+        assert np.isnan(geomap.map_data("median", flavor)).all()
+        assert np.array_equal(geomap.map_data("count", flavor), np.zeros(geomap.shape))
+
+    assert np.isfinite(geomap.map_data("median", Flavor.V)).any()
+    assert np.isfinite(geomap.map_data("median", Flavor.Y)).any()

--- a/swxsoc_reach/track/trackbase.py
+++ b/swxsoc_reach/track/trackbase.py
@@ -396,9 +396,9 @@ class REACHTrack(SWXData):
 
             # Skip if no observations for this flavor
             if not np.any(flavor_mask):
-log.warning(
-    f"No observations found for flavor {flavor.name}. Filling with empty maps."
-)
+                log.warning(
+                    f"No observations found for flavor {flavor.name}. Filling with empty maps."
+                )
                 for statistic in valid_statistics:
                     if statistic == "count":
                         statistic_maps[statistic].append(np.zeros(grid_shape))

--- a/swxsoc_reach/track/trackbase.py
+++ b/swxsoc_reach/track/trackbase.py
@@ -396,9 +396,9 @@ class REACHTrack(SWXData):
 
             # Skip if no observations for this flavor
             if not np.any(flavor_mask):
-                log.warning(
-                    f"No observations found for flavor {flavor.name}. Skipping."
-                )
+log.warning(
+    f"No observations found for flavor {flavor.name}. Filling with empty maps."
+)
                 for statistic in valid_statistics:
                     if statistic == "count":
                         statistic_maps[statistic].append(np.zeros(grid_shape))

--- a/swxsoc_reach/track/trackbase.py
+++ b/swxsoc_reach/track/trackbase.py
@@ -389,7 +389,9 @@ class REACHTrack(SWXData):
             statistic: [] for statistic in valid_statistics
         }
 
-        for flavor in Flavor.ordered():
+        # Loop over all flavors in canonical order and compute the statistics for each flavor, then append to the corresponding list in statistic_maps.
+        ordered_flavors = Flavor.ordered()
+        for flavor in ordered_flavors:
             flavor_mask = dosimeter_flavor_grid == flavor
 
             # Skip if no observations for this flavor
@@ -397,6 +399,11 @@ class REACHTrack(SWXData):
                 log.warning(
                     f"No observations found for flavor {flavor.name}. Skipping."
                 )
+                for statistic in valid_statistics:
+                    if statistic == "count":
+                        statistic_maps[statistic].append(np.zeros(grid_shape))
+                    else:
+                        statistic_maps[statistic].append(np.full(grid_shape, np.nan))
                 continue
 
             # Slice out the dose_rate data for this flavor
@@ -435,13 +442,13 @@ class REACHTrack(SWXData):
                         statistic_maps[statistic].append(np.full(grid_shape, np.nan))
 
         dosimeter_flavor_names = np.asarray(
-            [flavor.name for flavor in Flavor.ordered()], dtype="U"
+            [flavor.name for flavor in ordered_flavors], dtype="U"
         )
         dosimeter_flavor_ids = np.array(
-            [i for i in range(len(Flavor.ordered()))], dtype=int
+            [i for i in range(len(ordered_flavors))], dtype=int
         )
         dosimeter_flavor_labels = np.asarray(
-            [flavor.label for flavor in Flavor.ordered()], dtype="U"
+            [flavor.label for flavor in ordered_flavors], dtype="U"
         )
 
         # Define CDF Variables Dict.
@@ -515,6 +522,11 @@ class REACHTrack(SWXData):
         }
 
         for statistic in valid_statistics:
+            if len(statistic_maps[statistic]) != len(ordered_flavors):
+                raise ValueError(
+                    f"Statistic '{statistic}' has {len(statistic_maps[statistic])} flavor slices, "
+                    f"expected {len(ordered_flavors)}."
+                )
             unit = u.count if statistic == "count" else u.rad / u.s
             flavor_maps = np.stack(statistic_maps[statistic], axis=0, dtype=np.float32)
             variables[f"{statistic}_map"] = NDData(


### PR DESCRIPTION
- Fixed the GeoMap flavor-axis bug by enforcing a dense canonical six-flavor layout (U, V, W, X, Y, Z) in `to_geomap`, including explicit empty-map padding for missing flavors (`NaN` for non-`count` statistics and zeros for `count`) so metadata and tensor dimensions always stay aligned.
- Hardened flavor lookups in `map_data` with an explicit metadata-vs-data axis consistency check, so malformed or legacy sparse-axis products now fail with a clear error instead of silently returning mislabeled data or raising out-of-bounds indexing errors.
- Added regression coverage across track, geomap, and calibration tests to verify canonical flavor-axis shape, missing-flavor fill behavior, and successful end-to-end per-flavor plotting output generation.

resolves #48 